### PR TITLE
#207 chore: add terraform fmt -check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,10 @@ repos:
         entry: scripts/check_version_sync.sh
         pass_filenames: false
         files: ^(pyproject\.toml|package\.json)$
+
+      - id: terraform-fmt
+        name: terraform fmt (check)
+        language: system
+        entry: terraform fmt -check -recursive infra/terraform/
+        pass_filenames: false
+        files: \.tf$


### PR DESCRIPTION
Closes #207

## Summary
- Adds a local `terraform-fmt` pre-commit hook that runs `terraform fmt -check -recursive infra/terraform/`
- Scoped to `files: \.tf$` so it's a no-op on commits that don't touch HCL (consistent with how `eslint`/`prettier` are scoped to `.js$`)
- Check-only, no auto-fix — consistent with `ruff format --check` behaviour
- Uses `repo: local` / `language: system` like every other hook; no external plugin dependency

## Test plan
- [ ] `terraform fmt -check -recursive infra/terraform/` exits 0 on current files (verified locally)
- [ ] Pre-commit hook skips on commits with no `.tf` changes (observed in commit output: `terraform fmt (check)...(no files to check) Skipped`)
- [ ] Introduce a formatting violation in a `.tf` file, stage it, and confirm the hook fires and exits non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)