### PR TITLE
#217 feat: add schema deploy tooling and documented post-deploy procedure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,8 @@ exe.dev proxy: dev server at `https://power-map.exe.xyz:8001/`.
 
 | Situation | Action |
 |---|---|
-| After code change (production) | `sudo systemctl restart power-map` |
+| After code change (production) | `sudo systemctl restart power-map` — also applies any schema changes |
+| After schema change only (no restart) | `bash scripts/apply-schema.sh` |
 | Worktree dev testing | kill+restart dev server on 8001 with `--reload` from worktree dir |
 | Service debugging | `sudo journalctl -u power-map -f` |
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -119,6 +119,9 @@ sudo systemctl restart power-map     # applies schema then starts server
 sudo journalctl -u power-map -f      # watch startup; schema errors surface here
 ```
 
+If `infra/power-map.service` changed in the pull, reinstall the unit first (see § Service Management —
+"Install (first time or after updating infra/power-map.service)") before restarting.
+
 To apply schema without restarting (e.g. after a manual `git pull` mid-session):
 
 ```bash
@@ -127,7 +130,7 @@ bash scripts/apply-schema.sh
 
 **Note:** `apply-schema.sh` uses `MIGRATIONS_DATABASE_URL` (DDL privileges). `systemctl restart`
 loads this from `EnvironmentFile=/etc/power-map/.env` automatically; standalone invocation
-requires the env file to be sourced or `/etc/power-map/.env` to be present.
+requires `/etc/power-map/.env` to be present (the script loads it via `--env-file`).
 
 ## Development
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -108,6 +108,27 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now power-map
 ```
 
+## Deploy (after merging to main on the VM)
+
+Schema is applied automatically on every `systemctl restart` via `ExecStartPre=bash scripts/apply-schema.sh`.
+A bare restart is sufficient for both code-only and schema changes.
+
+```bash
+git pull                              # pull merged commits
+sudo systemctl restart power-map     # applies schema then starts server
+sudo journalctl -u power-map -f      # watch startup; schema errors surface here
+```
+
+To apply schema without restarting (e.g. after a manual `git pull` mid-session):
+
+```bash
+bash scripts/apply-schema.sh
+```
+
+**Note:** `apply-schema.sh` uses `MIGRATIONS_DATABASE_URL` (DDL privileges). `systemctl restart`
+loads this from `EnvironmentFile=/etc/power-map/.env` automatically; standalone invocation
+requires the env file to be sourced or `/etc/power-map/.env` to be present.
+
 ## Development
 
 Dev server runs on port 8001 with `--reload`. Always run from a git worktree — never the main checkout.

--- a/infra/power-map.service
+++ b/infra/power-map.service
@@ -10,6 +10,7 @@ EnvironmentFile=-/home/exedev/power-map/.env
 # uv run resolves the venv from pyproject.toml — no hardcoded .venv path
 # Requires uv on PATH (/usr/local/bin/uv); verify: systemctl show power-map --property=Environment
 ExecStartPre=uv sync --quiet
+ExecStartPre=bash scripts/apply-schema.sh
 ExecStart=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8000 --workers 2
 Restart=on-failure
 RestartSec=5s

--- a/scripts/apply-schema.sh
+++ b/scripts/apply-schema.sh
@@ -11,18 +11,20 @@
 
 set -euo pipefail
 
-: "${MIGRATIONS_DATABASE_URL:?MIGRATIONS_DATABASE_URL not set — source /etc/power-map/.env}"
-
 env_args=()
 [ -f /etc/power-map/.env ] && env_args+=(--env-file /etc/power-map/.env)
 [ -f .env ]                && env_args+=(--env-file .env)
 
 uv run "${env_args[@]}" python - <<'PY'
-import asyncio, asyncpg, os
+import asyncio, asyncpg, os, sys
 from src.core.db import apply_schema
 
+url = os.environ.get("MIGRATIONS_DATABASE_URL")
+if not url:
+    sys.exit("MIGRATIONS_DATABASE_URL not set — check /etc/power-map/.env")
+
 async def main():
-    conn = await asyncpg.connect(os.environ["MIGRATIONS_DATABASE_URL"])
+    conn = await asyncpg.connect(url)
     try:
         await apply_schema(conn)
     finally:

--- a/scripts/apply-schema.sh
+++ b/scripts/apply-schema.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Apply schema.sql to the production database using MIGRATIONS_DATABASE_URL.
+#
+# Uses the migrations user (DDL privileges) rather than the app user (DML only).
+# Idempotent — safe to re-run; all DDL uses IF NOT EXISTS guards.
+#
+# Usage (from repo root):
+#   bash scripts/apply-schema.sh
+#
+# Called automatically by the systemd unit (ExecStartPre) on every restart.
+
+set -euo pipefail
+
+: "${MIGRATIONS_DATABASE_URL:?MIGRATIONS_DATABASE_URL not set — source /etc/power-map/.env}"
+
+env_args=()
+[ -f /etc/power-map/.env ] && env_args+=(--env-file /etc/power-map/.env)
+[ -f .env ]                && env_args+=(--env-file .env)
+
+uv run "${env_args[@]}" python - <<'PY'
+import asyncio, asyncpg, os
+from src.core.db import apply_schema
+
+async def main():
+    conn = await asyncpg.connect(os.environ["MIGRATIONS_DATABASE_URL"])
+    try:
+        await apply_schema(conn)
+    finally:
+        await conn.close()
+    print("schema applied")
+
+asyncio.run(main())
+PY


### PR DESCRIPTION
Closes #217

## Summary

- `scripts/apply-schema.sh` — zero-arg wrapper that runs `apply_schema` via `MIGRATIONS_DATABASE_URL` (migrations user has DDL privileges; app user doesn't). Idempotent; safe to re-run. Fails loudly if `MIGRATIONS_DATABASE_URL` is unset.
- `infra/power-map.service` — `ExecStartPre=bash scripts/apply-schema.sh` added after `uv sync`. Schema is now applied automatically on every `systemctl restart`; a bare restart is sufficient for both code and schema changes.
- `docs/COMMANDS.md` — new **Deploy** section documenting the restart-applies-schema contract and the standalone `apply-schema.sh` invocation pattern.
- `AGENTS.md` — added schema-change row to the service management table so agents don't omit the step.

## Notes

- `apply_schema` wraps the entire schema in a transaction ([db.py:97](src/core/db.py#L97)), so all DDL succeeds or all fails atomically.
- `CREATE INDEX CONCURRENTLY` cannot run inside a transaction — if ever added to `schema.sql`, `apply_schema` will fail. Deferred per the issue; worth noting if that path is taken.
- `EnvironmentFile=/etc/power-map/.env` in the unit already injects env vars before `ExecStartPre` runs, so `MIGRATIONS_DATABASE_URL` is available without the script re-reading the file. The `env_args` block in the script is kept for standalone invocation.
- After merging, the unit file must be re-installed: `sudo cp infra/power-map.service /etc/systemd/system/power-map.service && sudo systemctl daemon-reload`.

## Test plan

- [ ] `bash scripts/apply-schema.sh` on a clean DB applies schema and prints "schema applied"
- [ ] Re-running is a no-op (idempotent)
- [ ] Running without `MIGRATIONS_DATABASE_URL` set exits with a clear error message
- [ ] `sudo systemctl restart power-map` after unit reinstall applies schema then starts server (check `journalctl -u power-map`)
- [ ] `sudo systemctl restart power-map` with bad SQL in schema.sql blocks server start (fail-loud behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)