### PR TITLE
#212 perf: add archived_at partial indexes on entity tables

### DIFF
--- a/src/core/schema.sql
+++ b/src/core/schema.sql
@@ -2193,6 +2193,28 @@ CREATE INDEX IF NOT EXISTS idx_person_names_name_gist_trgm
     WHERE visibility = 'public';
 
 -- ---------------------------------------------------------------------------
+-- Partial indexes on archived_at IS NULL for active-row queries
+--
+-- Used by dashboard/entities COUNT(*) subqueries and list-page filters.
+-- Partial: only active rows are indexed; archiving a row removes it.
+-- Applied without CONCURRENTLY (schema.sql runs inside a transaction).
+-- Pre-deploy on live DB: run CREATE INDEX CONCURRENTLY manually first;
+-- apply_schema then skips via IF NOT EXISTS.
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_people_archived_at
+    ON people (archived_at) WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_organizations_archived_at
+    ON organizations (archived_at) WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_roles_archived_at
+    ON roles (archived_at) WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_role_assignments_archived_at
+    ON role_assignments (archived_at) WHERE archived_at IS NULL;
+
+-- ---------------------------------------------------------------------------
 -- Shared dup-count cache (multi-worker safe)
 -- ---------------------------------------------------------------------------
 

--- a/src/core/schema.sql
+++ b/src/core/schema.sql
@@ -2198,8 +2198,8 @@ CREATE INDEX IF NOT EXISTS idx_person_names_name_gist_trgm
 -- Used by dashboard/entities COUNT(*) subqueries and list-page filters.
 -- Partial: only active rows are indexed; archiving a row removes it.
 -- Applied without CONCURRENTLY (schema.sql runs inside a transaction).
--- Pre-deploy on live DB: run CREATE INDEX CONCURRENTLY manually first;
--- apply_schema then skips via IF NOT EXISTS.
+-- TODO #220: apply_schema should create non-unique indexes CONCURRENTLY
+-- outside the transaction to avoid the write-lock during index build.
 -- ---------------------------------------------------------------------------
 
 CREATE INDEX IF NOT EXISTS idx_people_archived_at

--- a/tests/core/test_schema_archived_at_indexes.py
+++ b/tests/core/test_schema_archived_at_indexes.py
@@ -36,11 +36,11 @@ async def test_archived_at_partial_index_exists(db, table, index_name):
         FROM pg_indexes
         WHERE tablename = $1
           AND indexname = $2
+          AND indexdef ILIKE '%archived_at is null%'
         """,
         table,
         index_name,
     )
-    assert row is not None, f"missing partial index {index_name} on {table}"
-    assert "archived_at IS NULL" in row["indexdef"], (
-        f"index {index_name} on {table} must be partial WHERE archived_at IS NULL"
+    assert row is not None, (
+        f"missing partial index {index_name} on {table} WHERE archived_at IS NULL"
     )

--- a/tests/core/test_schema_archived_at_indexes.py
+++ b/tests/core/test_schema_archived_at_indexes.py
@@ -1,0 +1,46 @@
+"""Integration tests: partial indexes on archived_at IS NULL for entity tables."""
+
+import pytest
+import pytest_asyncio
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def db(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            yield conn
+        finally:
+            await tr.rollback()
+
+
+@pytest.mark.parametrize(
+    "table,index_name",
+    [
+        ("people", "idx_people_archived_at"),
+        ("organizations", "idx_organizations_archived_at"),
+        ("roles", "idx_roles_archived_at"),
+        ("role_assignments", "idx_role_assignments_archived_at"),
+    ],
+)
+async def test_archived_at_partial_index_exists(db, table, index_name):
+    """Partial index on archived_at IS NULL must exist for COUNT(*) index-only scans."""
+    row = await db.fetchrow(
+        """
+        SELECT indexdef
+        FROM pg_indexes
+        WHERE tablename = $1
+          AND indexname = $2
+        """,
+        table,
+        index_name,
+    )
+    assert row is not None, f"missing partial index {index_name} on {table}"
+    assert "archived_at IS NULL" in row["indexdef"], (
+        f"index {index_name} on {table} must be partial WHERE archived_at IS NULL"
+    )


### PR DESCRIPTION
Closes #212

## Summary
- Adds `CREATE INDEX IF NOT EXISTS ... WHERE archived_at IS NULL` for `people`, `organizations`, `roles`, and `role_assignments`
- Dashboard and entities page `COUNT(*) WHERE archived_at IS NULL` subqueries now eligible for index-only scans instead of sequential scans
- Indexes are partial (active rows only), so archive mutations remove rows from the index automatically

## Notes
- No `CONCURRENTLY` in schema.sql — `apply_schema` runs inside a transaction where `CONCURRENTLY` is illegal. For a live pre-deploy run: `CREATE INDEX CONCURRENTLY` manually first, then `apply_schema` skips via `IF NOT EXISTS`
- `roles` and `role_assignments` already had partial unique indexes with the same `WHERE archived_at IS NULL` predicate; these dedicated thin indexes are more efficient for full-table count scans
- 4 new integration tests in `tests/core/test_schema_archived_at_indexes.py` verify index presence and partial predicate

## Test plan
- [x] `pytest tests/core/test_schema_archived_at_indexes.py -m integration` — 4/4 pass
- [x] Full unit suite — 608 passed, no regressions
- [x] `bash scripts/apply-schema.sh` — clean apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)