### PR TITLE
#221 fix: show canonical name in dup review cards

### DIFF
--- a/src/api/admin/orgs_merge.py
+++ b/src/api/admin/orgs_merge.py
@@ -30,8 +30,14 @@ async def _fetch_duplicate_pairs(db) -> list:
         return await db.fetch(
             f"""WITH cands AS (
                 SELECT DISTINCT ON (a.id, b.id)
-                    a.id AS a_id, dn_a.name AS a_name_raw, a.created_at AS a_created,
-                    b.id AS b_id, dn_b.name AS b_name_raw, b.created_at AS b_created,
+                    a.id AS a_id,
+                    dn_a.name AS a_match_name,
+                    dn_a.is_canonical AS a_match_is_canonical,
+                    a.created_at AS a_created,
+                    b.id AS b_id,
+                    dn_b.name AS b_match_name,
+                    dn_b.is_canonical AS b_match_is_canonical,
+                    b.created_at AS b_created,
                     similarity(dn_a.name, dn_b.name) AS score,
                     (SELECT count(*) FROM roles
                      WHERE organization_id = a.id AND archived_at IS NULL) AS a_roles,
@@ -42,25 +48,21 @@ async def _fetch_duplicate_pairs(db) -> list:
             )
             SELECT
                 cands.a_id,
-                COALESCE(
-                    cands.a_name_raw || ' (' || acr_a.acronym || ')',
-                    cands.a_name_raw
-                ) AS a_name,
+                COALESCE(vdn_a.display_name, cands.a_match_name) AS a_name,
+                cands.a_match_name,
+                cands.a_match_is_canonical,
                 cands.a_created,
                 cands.b_id,
-                COALESCE(
-                    cands.b_name_raw || ' (' || acr_b.acronym || ')',
-                    cands.b_name_raw
-                ) AS b_name,
+                COALESCE(vdn_b.display_name, cands.b_match_name) AS b_name,
+                cands.b_match_name,
+                cands.b_match_is_canonical,
                 cands.b_created,
                 cands.score,
                 cands.a_roles,
                 cands.b_roles
             FROM cands
-            LEFT JOIN organization_acronyms acr_a
-                ON acr_a.organization_id = cands.a_id AND acr_a.is_canonical = TRUE
-            LEFT JOIN organization_acronyms acr_b
-                ON acr_b.organization_id = cands.b_id AND acr_b.is_canonical = TRUE
+            LEFT JOIN v_org_display_names vdn_a ON vdn_a.organization_id = cands.a_id
+            LEFT JOIN v_org_display_names vdn_b ON vdn_b.organization_id = cands.b_id
             ORDER BY cands.score DESC"""
         )
     except asyncpg.exceptions.UndefinedFunctionError:

--- a/src/api/admin/people_merge.py
+++ b/src/api/admin/people_merge.py
@@ -75,10 +75,34 @@ async def _fetch_duplicate_pairs(db) -> list:
     """Return near-duplicate person pairs; empty list if pg_trgm not installed."""
     try:
         return await db.fetch(
-            f"""SELECT * FROM (
+            f"""SELECT
+                sub.a_id,
+                COALESCE(vdn_a.display_name, sub.a_match_name) AS a_name,
+                sub.a_match_name,
+                sub.a_match_is_canonical,
+                sub.a_match_visibility,
+                sub.a_created,
+                sub.b_id,
+                COALESCE(vdn_b.display_name, sub.b_match_name) AS b_name,
+                sub.b_match_name,
+                sub.b_match_is_canonical,
+                sub.b_match_visibility,
+                sub.b_created,
+                sub.score,
+                sub.a_roles,
+                sub.b_roles
+            FROM (
                 SELECT DISTINCT ON (a.id, b.id)
-                    a.id AS a_id, dn_a.name AS a_name, a.created_at AS a_created,
-                    b.id AS b_id, dn_b.name AS b_name, b.created_at AS b_created,
+                    a.id AS a_id,
+                    dn_a.name AS a_match_name,
+                    dn_a.is_canonical AS a_match_is_canonical,
+                    dn_a.visibility AS a_match_visibility,
+                    a.created_at AS a_created,
+                    b.id AS b_id,
+                    dn_b.name AS b_match_name,
+                    dn_b.is_canonical AS b_match_is_canonical,
+                    dn_b.visibility AS b_match_visibility,
+                    b.created_at AS b_created,
                     similarity(dn_a.name, dn_b.name) AS score,
                     (SELECT count(*) FROM role_assignments
                      WHERE person_id = a.id AND archived_at IS NULL) AS a_roles,
@@ -87,6 +111,8 @@ async def _fetch_duplicate_pairs(db) -> list:
                 {CANDIDATE_WHERE}
                 ORDER BY a.id, b.id, similarity(dn_a.name, dn_b.name) DESC
             ) sub
+            LEFT JOIN v_person_display_names vdn_a ON vdn_a.person_id = sub.a_id
+            LEFT JOIN v_person_display_names vdn_b ON vdn_b.person_id = sub.b_id
             ORDER BY score DESC"""
         )
     except asyncpg.exceptions.UndefinedFunctionError:

--- a/src/templates/admin/orgs/_duplicates_region.html
+++ b/src/templates/admin/orgs/_duplicates_region.html
@@ -14,12 +14,14 @@
     {% for p in pairs %}
     <tr>
       <td>
-        <a href="/admin/orgs/{{ p.a_id }}/">{{ p.a_name }}</a><br>
-        <small style="color:var(--color-text-muted)">{{ p.a_created.strftime('%Y-%m-%d') }} · {{ p.a_roles }} role{{ 's' if p.a_roles != 1 else '' }}</small>
+        <a href="/admin/orgs/{{ p.a_id }}/">{{ p.a_name }}</a>
+        {% if not p.a_match_is_canonical %}<br><small style="color:var(--color-text-muted)">matched via: {{ p.a_match_name }}</small>{% endif %}
+        <br><small style="color:var(--color-text-muted)">{{ p.a_created.strftime('%Y-%m-%d') }} · {{ p.a_roles }} role{{ 's' if p.a_roles != 1 else '' }}</small>
       </td>
       <td>
-        <a href="/admin/orgs/{{ p.b_id }}/">{{ p.b_name }}</a><br>
-        <small style="color:var(--color-text-muted)">{{ p.b_created.strftime('%Y-%m-%d') }} · {{ p.b_roles }} role{{ 's' if p.b_roles != 1 else '' }}</small>
+        <a href="/admin/orgs/{{ p.b_id }}/">{{ p.b_name }}</a>
+        {% if not p.b_match_is_canonical %}<br><small style="color:var(--color-text-muted)">matched via: {{ p.b_match_name }}</small>{% endif %}
+        <br><small style="color:var(--color-text-muted)">{{ p.b_created.strftime('%Y-%m-%d') }} · {{ p.b_roles }} role{{ 's' if p.b_roles != 1 else '' }}</small>
       </td>
       <td>{{ "%.0f%%"|format(p.score * 100) }}</td>
       <td class="dup-actions">

--- a/src/templates/admin/orgs/_duplicates_region.html
+++ b/src/templates/admin/orgs/_duplicates_region.html
@@ -15,12 +15,16 @@
     <tr>
       <td>
         <a href="/admin/orgs/{{ p.a_id }}/">{{ p.a_name }}</a>
-        {% if not p.a_match_is_canonical %}<br><small style="color:var(--color-text-muted)">matched via: {{ p.a_match_name }}</small>{% endif %}
+        {% if not p.a_match_is_canonical and p.a_name != p.a_match_name %}
+        <br><small style="color:var(--color-text-muted)">matched via: {{ p.a_match_name }}</small>
+        {% endif %}
         <br><small style="color:var(--color-text-muted)">{{ p.a_created.strftime('%Y-%m-%d') }} · {{ p.a_roles }} role{{ 's' if p.a_roles != 1 else '' }}</small>
       </td>
       <td>
         <a href="/admin/orgs/{{ p.b_id }}/">{{ p.b_name }}</a>
-        {% if not p.b_match_is_canonical %}<br><small style="color:var(--color-text-muted)">matched via: {{ p.b_match_name }}</small>{% endif %}
+        {% if not p.b_match_is_canonical and p.b_name != p.b_match_name %}
+        <br><small style="color:var(--color-text-muted)">matched via: {{ p.b_match_name }}</small>
+        {% endif %}
         <br><small style="color:var(--color-text-muted)">{{ p.b_created.strftime('%Y-%m-%d') }} · {{ p.b_roles }} role{{ 's' if p.b_roles != 1 else '' }}</small>
       </td>
       <td>{{ "%.0f%%"|format(p.score * 100) }}</td>

--- a/src/templates/admin/people/_duplicates_region.html
+++ b/src/templates/admin/people/_duplicates_region.html
@@ -14,12 +14,14 @@
     {% for p in pairs %}
     <tr>
       <td>
-        <a href="/admin/people/{{ p.a_id }}/">{{ p.a_name }}</a><br>
-        <small style="color:var(--color-text-muted)">{{ p.a_created.strftime('%Y-%m-%d') }} · {{ p.a_roles }} assignment{{ 's' if p.a_roles != 1 else '' }}</small>
+        <a href="/admin/people/{{ p.a_id }}/">{{ p.a_name }}</a>
+        {% if not p.a_match_is_canonical and p.a_match_visibility == 'public' %}<br><small style="color:var(--color-text-muted)">matched via: {{ p.a_match_name }}</small>{% endif %}
+        <br><small style="color:var(--color-text-muted)">{{ p.a_created.strftime('%Y-%m-%d') }} · {{ p.a_roles }} assignment{{ 's' if p.a_roles != 1 else '' }}</small>
       </td>
       <td>
-        <a href="/admin/people/{{ p.b_id }}/">{{ p.b_name }}</a><br>
-        <small style="color:var(--color-text-muted)">{{ p.b_created.strftime('%Y-%m-%d') }} · {{ p.b_roles }} assignment{{ 's' if p.b_roles != 1 else '' }}</small>
+        <a href="/admin/people/{{ p.b_id }}/">{{ p.b_name }}</a>
+        {% if not p.b_match_is_canonical and p.b_match_visibility == 'public' %}<br><small style="color:var(--color-text-muted)">matched via: {{ p.b_match_name }}</small>{% endif %}
+        <br><small style="color:var(--color-text-muted)">{{ p.b_created.strftime('%Y-%m-%d') }} · {{ p.b_roles }} assignment{{ 's' if p.b_roles != 1 else '' }}</small>
       </td>
       <td>{{ "%.0f%%"|format(p.score * 100) }}</td>
       <td class="dup-actions">

--- a/src/templates/admin/people/_duplicates_region.html
+++ b/src/templates/admin/people/_duplicates_region.html
@@ -15,12 +15,16 @@
     <tr>
       <td>
         <a href="/admin/people/{{ p.a_id }}/">{{ p.a_name }}</a>
-        {% if not p.a_match_is_canonical and p.a_match_visibility == 'public' %}<br><small style="color:var(--color-text-muted)">matched via: {{ p.a_match_name }}</small>{% endif %}
+        {% if not p.a_match_is_canonical and p.a_match_visibility == 'public' and p.a_name != p.a_match_name %}
+        <br><small style="color:var(--color-text-muted)">matched via: {{ p.a_match_name }}</small>
+        {% endif %}
         <br><small style="color:var(--color-text-muted)">{{ p.a_created.strftime('%Y-%m-%d') }} · {{ p.a_roles }} assignment{{ 's' if p.a_roles != 1 else '' }}</small>
       </td>
       <td>
         <a href="/admin/people/{{ p.b_id }}/">{{ p.b_name }}</a>
-        {% if not p.b_match_is_canonical and p.b_match_visibility == 'public' %}<br><small style="color:var(--color-text-muted)">matched via: {{ p.b_match_name }}</small>{% endif %}
+        {% if not p.b_match_is_canonical and p.b_match_visibility == 'public' and p.b_name != p.b_match_name %}
+        <br><small style="color:var(--color-text-muted)">matched via: {{ p.b_match_name }}</small>
+        {% endif %}
         <br><small style="color:var(--color-text-muted)">{{ p.b_created.strftime('%Y-%m-%d') }} · {{ p.b_roles }} assignment{{ 's' if p.b_roles != 1 else '' }}</small>
       </td>
       <td>{{ "%.0f%%"|format(p.score * 100) }}</td>

--- a/tests/api/admin/test_orgs_duplicates.py
+++ b/tests/api/admin/test_orgs_duplicates.py
@@ -844,9 +844,10 @@ async def test_org_alternate_name_match_detected(client, org_pair_alternate_matc
 
 async def test_org_alternate_name_match_shows_canonical_name(client, org_pair_alternate_match):
     """Dup card must show canonical name for each org, not the alternate that drove the match."""
+    id_a, id_b = org_pair_alternate_match
     response = client.get("/admin/orgs/duplicates/", headers=AUTH_HEADERS)
     assert response.status_code == 200
-    assert "Acme Consolidated Corporation" in response.text
+    assert f'/admin/orgs/{id_a}/">Acme Consolidated Corporation' in response.text
 
 
 async def test_org_alternate_name_match_shows_matched_via(client, org_pair_alternate_match):

--- a/tests/api/admin/test_orgs_duplicates.py
+++ b/tests/api/admin/test_orgs_duplicates.py
@@ -842,6 +842,20 @@ async def test_org_alternate_name_match_detected(client, org_pair_alternate_matc
     assert f"/admin/orgs/{id_a}/merge-preview/{id_b}/" in response.text
 
 
+async def test_org_alternate_name_match_shows_canonical_name(client, org_pair_alternate_match):
+    """Dup card must show canonical name for each org, not the alternate that drove the match."""
+    response = client.get("/admin/orgs/duplicates/", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    assert "Acme Consolidated Corporation" in response.text
+
+
+async def test_org_alternate_name_match_shows_matched_via(client, org_pair_alternate_match):
+    """Dup card must show 'matched via:' secondary line when the matching name is non-canonical."""
+    response = client.get("/admin/orgs/duplicates/", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    assert "matched via: Acme Corp" in response.text
+
+
 @pytest_asyncio.fixture(loop_scope="session")
 async def org_pair_multi_name(db_pool):
     """Both orgs carry two names that all cross-match above 0.85.

--- a/tests/api/admin/test_orgs_duplicates.py
+++ b/tests/api/admin/test_orgs_duplicates.py
@@ -848,13 +848,17 @@ async def test_org_alternate_name_match_shows_canonical_name(client, org_pair_al
     response = client.get("/admin/orgs/duplicates/", headers=AUTH_HEADERS)
     assert response.status_code == 200
     assert f'/admin/orgs/{id_a}/">Acme Consolidated Corporation' in response.text
+    assert f'/admin/orgs/{id_b}/">Acme Corp' in response.text
 
 
 async def test_org_alternate_name_match_shows_matched_via(client, org_pair_alternate_match):
     """Dup card must show 'matched via:' secondary line when the matching name is non-canonical."""
+    id_a, _id_b = org_pair_alternate_match
     response = client.get("/admin/orgs/duplicates/", headers=AUTH_HEADERS)
     assert response.status_code == 200
-    assert "matched via: Acme Corp" in response.text
+    section_start = response.text.find(f'/admin/orgs/{id_a}/">')
+    assert section_start != -1
+    assert "matched via: Acme Corp" in response.text[section_start : section_start + 300]
 
 
 @pytest_asyncio.fixture(loop_scope="session")

--- a/tests/api/admin/test_people_duplicates.py
+++ b/tests/api/admin/test_people_duplicates.py
@@ -832,13 +832,17 @@ async def test_alternate_name_match_shows_canonical_name(client, person_pair_alt
     response = client.get("/admin/people/duplicates/", headers=AUTH_HEADERS)
     assert response.status_code == 200
     assert f'/admin/people/{id_a}/">Jordan Fitzgerald Marsh' in response.text
+    assert f'/admin/people/{id_b}/">Jordan Marsh' in response.text
 
 
 async def test_alternate_name_match_shows_matched_via_public(client, person_pair_alternate_match):
     """Dup card shows 'matched via:' secondary line for a public alternate match."""
+    id_a, _id_b = person_pair_alternate_match
     response = client.get("/admin/people/duplicates/", headers=AUTH_HEADERS)
     assert response.status_code == 200
-    assert "matched via: Jordan Marsh" in response.text
+    section_start = response.text.find(f'/admin/people/{id_a}/">')
+    assert section_start != -1
+    assert "matched via: Jordan Marsh" in response.text[section_start : section_start + 300]
 
 
 async def test_legal_only_name_match_does_not_show_matched_via(

--- a/tests/api/admin/test_people_duplicates.py
+++ b/tests/api/admin/test_people_duplicates.py
@@ -824,3 +824,27 @@ async def test_legal_only_name_detected(client, person_pair_legal_only_match):
     response = client.get("/admin/people/duplicates/", headers=AUTH_HEADERS)
     assert response.status_code == 200
     assert f"/admin/people/{id_a}/merge/{id_b}/" in response.text
+
+
+async def test_alternate_name_match_shows_canonical_name(client, person_pair_alternate_match):
+    """Dup card must show canonical name ('Jordan Fitzgerald Marsh'), not the matched alternate."""
+    response = client.get("/admin/people/duplicates/", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    assert "Jordan Fitzgerald Marsh" in response.text
+
+
+async def test_alternate_name_match_shows_matched_via_public(client, person_pair_alternate_match):
+    """Dup card shows 'matched via:' secondary line for a public alternate match."""
+    response = client.get("/admin/people/duplicates/", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    assert "matched via: Jordan Marsh" in response.text
+
+
+async def test_legal_only_name_match_does_not_show_matched_via(
+    client, person_pair_legal_only_match
+):
+    """Dup card must NOT reveal a legal_only matched name in 'matched via:' secondary line."""
+    response = client.get("/admin/people/duplicates/", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    assert "Peter Wimsey" in response.text
+    assert "matched via: Harriet Vane" not in response.text

--- a/tests/api/admin/test_people_duplicates.py
+++ b/tests/api/admin/test_people_duplicates.py
@@ -828,9 +828,10 @@ async def test_legal_only_name_detected(client, person_pair_legal_only_match):
 
 async def test_alternate_name_match_shows_canonical_name(client, person_pair_alternate_match):
     """Dup card must show canonical name ('Jordan Fitzgerald Marsh'), not the matched alternate."""
+    id_a, id_b = person_pair_alternate_match
     response = client.get("/admin/people/duplicates/", headers=AUTH_HEADERS)
     assert response.status_code == 200
-    assert "Jordan Fitzgerald Marsh" in response.text
+    assert f'/admin/people/{id_a}/">Jordan Fitzgerald Marsh' in response.text
 
 
 async def test_alternate_name_match_shows_matched_via_public(client, person_pair_alternate_match):


### PR DESCRIPTION
Closes #221.

## Summary

- Both `_fetch_duplicate_pairs` functions now join `v_org_display_names` / `v_person_display_names` so the primary link text on the review card is always the canonical name — not the alternate that happened to score highest in the similarity join.
- The best-matching name is retained as `a_match_name` / `b_match_name` and exposed as a secondary "matched via: …" line when it differs from canonical (`a_match_is_canonical = FALSE`).
- For people, the "matched via:" line is additionally gated on `visibility='public'` — `legal_only` matches surface the pair but don't reveal the protected name in the UI.

## Test plan

- [ ] `test_org_alternate_name_match_shows_canonical_name` — card shows "Acme Consolidated Corporation", not "Acme Corp"
- [ ] `test_org_alternate_name_match_shows_matched_via` — secondary line reads "matched via: Acme Corp"
- [ ] `test_alternate_name_match_shows_canonical_name` — card shows "Jordan Fitzgerald Marsh"
- [ ] `test_alternate_name_match_shows_matched_via_public` — secondary line reads "matched via: Jordan Marsh"
- [ ] `test_legal_only_name_match_does_not_show_matched_via` — "Peter Wimsey" shown; "matched via: Harriet Vane" absent
- [ ] All 973 existing admin integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)