### PR TITLE
#232 feat: UNIQUE constraint on entity_addresses + people_merge dedup DELETE

### DIFF
--- a/src/api/admin/orgs_merge.py
+++ b/src/api/admin/orgs_merge.py
@@ -281,7 +281,7 @@ async def _execute_merge(
         # Dedup: remove loser rows where winner already has the same logical record.
         # Each table that follows in the bulk reassign loop needs a corresponding dedup
         # DELETE here; omitting one silently produces duplicate rows after merge.
-        # entity_addresses: deduplicates by address_id FK only; #232 tracks normalised-form dedup.
+        # entity_addresses: FK-level dedup only; normalised-form dedup lives in write_addresses().
         await db.execute(
             """DELETE FROM entity_addresses
                WHERE entity_type='organization' AND entity_id=$1

--- a/src/api/admin/people_merge.py
+++ b/src/api/admin/people_merge.py
@@ -262,6 +262,18 @@ async def merge_person_into(
         winner_id,
     )
 
+    # entity_addresses: drop loser rows where winner already has same address_id+type.
+    await db.execute(
+        """DELETE FROM entity_addresses
+           WHERE entity_type='person' AND entity_id=$1
+             AND (address_id, address_type) IN (
+                 SELECT address_id, address_type FROM entity_addresses
+                 WHERE entity_type='person' AND entity_id=$2
+             )""",
+        loser_id,
+        winner_id,
+    )
+
     # Polymorphic entity tables.
     for table in (
         "contact_methods",

--- a/src/api/admin/people_merge.py
+++ b/src/api/admin/people_merge.py
@@ -274,6 +274,18 @@ async def merge_person_into(
         winner_id,
     )
 
+    # contact_methods: drop loser rows where winner already has same contact_type+value.
+    await db.execute(
+        """DELETE FROM contact_methods
+           WHERE entity_type='person' AND entity_id=$1
+             AND (contact_type, value) IN (
+                 SELECT contact_type, value FROM contact_methods
+                 WHERE entity_type='person' AND entity_id=$2
+             )""",
+        loser_id,
+        winner_id,
+    )
+
     # Polymorphic entity tables.
     for table in (
         "contact_methods",

--- a/src/core/schema.sql
+++ b/src/core/schema.sql
@@ -2243,3 +2243,24 @@ ALTER TABLE contact_methods DROP CONSTRAINT IF EXISTS contact_methods_entity_con
 ALTER TABLE contact_methods
     ADD CONSTRAINT contact_methods_entity_contact_uniq
     UNIQUE (entity_type, entity_id, contact_type, value);
+
+-- ---------------------------------------------------------------------------
+-- Unique constraint: entity_addresses (entity_type, entity_id, address_type, address_id)
+--
+-- Closes the FK-level duplicate hole produced by merge. Normalised-form dedup
+-- (same physical address, different addresses rows) is handled at write time by
+-- write_addresses() via COALESCE(standardized, raw_input); this constraint
+-- catches exact-FK duplicates that _execute_merge could produce.
+-- ---------------------------------------------------------------------------
+
+DELETE FROM entity_addresses a USING entity_addresses b
+WHERE a.id > b.id
+  AND a.entity_type  = b.entity_type
+  AND a.entity_id    = b.entity_id
+  AND a.address_type = b.address_type
+  AND a.address_id   = b.address_id;
+
+ALTER TABLE entity_addresses DROP CONSTRAINT IF EXISTS entity_addresses_entity_addr_uniq;
+ALTER TABLE entity_addresses
+    ADD CONSTRAINT entity_addresses_entity_addr_uniq
+    UNIQUE (entity_type, entity_id, address_type, address_id);

--- a/tests/api/admin/test_orgs_duplicates.py
+++ b/tests/api/admin/test_orgs_duplicates.py
@@ -1121,3 +1121,140 @@ async def test_merge_deduplicates_shared_contact_method(client, db_pool):
                 )
                 await conn.execute("DELETE FROM organization_names WHERE organization_id=$1", oid)
                 await conn.execute("DELETE FROM organizations WHERE id=$1", oid)
+
+
+# entity_addresses dedup during merge (#232)
+# ---------------------------------------------------------------------------
+
+
+async def _add_org_address(
+    conn, org_id: str, raw_input: str, address_type: str = "mailing"
+) -> tuple[str, str]:
+    """Insert addresses + entity_addresses for an org; return (address_id, entity_address_id)."""
+    aid = generate_id()
+    eaid = generate_id()
+    await conn.execute(
+        "INSERT INTO addresses (id, raw_input, country) VALUES ($1, $2, 'US')",
+        aid,
+        raw_input,
+    )
+    await conn.execute(
+        "INSERT INTO entity_addresses"
+        " (id, entity_type, entity_id, address_id, address_type)"
+        " VALUES ($1, 'organization', $2, $3, $4)",
+        eaid,
+        org_id,
+        aid,
+        address_type,
+    )
+    return aid, eaid
+
+
+async def test_merge_reassigns_unique_org_address(client, db_pool):
+    """Loser org's address not on winner is transferred after merge."""
+    async with db_pool.acquire() as conn:
+        winner_id = await _make_org(conn, "Winner Org Addr Test")
+        loser_id = await _make_org(conn, "Loser Org Addr Test")
+        await _add_org_address(conn, loser_id, "100 Unique Org St")
+
+    try:
+        response = client.post(
+            f"/admin/orgs/{winner_id}/merge/{loser_id}/",
+            headers=AUTH_HEADERS,
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+        async with db_pool.acquire() as conn:
+            count = await conn.fetchval(
+                "SELECT count(*) FROM entity_addresses"
+                " WHERE entity_type='organization' AND entity_id=$1",
+                winner_id,
+            )
+        assert count == 1
+    finally:
+        async with db_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT address_id FROM entity_addresses"
+                " WHERE entity_type='organization' AND entity_id=$1",
+                winner_id,
+            )
+            await conn.execute(
+                "DELETE FROM entity_addresses WHERE entity_type='organization' AND entity_id=$1",
+                winner_id,
+            )
+            if rows:
+                await conn.execute(
+                    "DELETE FROM addresses WHERE id = ANY($1::text[])",
+                    [r["address_id"] for r in rows],
+                )
+            for oid in (winner_id, loser_id):
+                await conn.execute("DELETE FROM organization_names WHERE organization_id=$1", oid)
+                await conn.execute("DELETE FROM organizations WHERE id=$1", oid)
+
+
+async def test_merge_deduplicates_shared_org_address(client, db_pool):
+    """Shared address (same address_id + type) on both orgs yields one row on winner."""
+    async with db_pool.acquire() as conn:
+        winner_id = await _make_org(conn, "Winner Org Addr Dedup Test")
+        loser_id = await _make_org(conn, "Loser Org Addr Dedup Test")
+        shared_aid = generate_id()
+        await conn.execute(
+            "INSERT INTO addresses (id, raw_input, country)"
+            " VALUES ($1, '100 Shared Org Ave', 'US')",
+            shared_aid,
+        )
+        for oid in (winner_id, loser_id):
+            await conn.execute(
+                "INSERT INTO entity_addresses"
+                " (id, entity_type, entity_id, address_id, address_type)"
+                " VALUES ($1, 'organization', $2, $3, 'mailing')",
+                generate_id(),
+                oid,
+                shared_aid,
+            )
+        unique_aid = generate_id()
+        await conn.execute(
+            "INSERT INTO addresses (id, raw_input, country) VALUES ($1, '200 Unique Org Rd', 'US')",
+            unique_aid,
+        )
+        await conn.execute(
+            "INSERT INTO entity_addresses"
+            " (id, entity_type, entity_id, address_id, address_type)"
+            " VALUES ($1, 'organization', $2, $3, 'physical')",
+            generate_id(),
+            loser_id,
+            unique_aid,
+        )
+
+    try:
+        response = client.post(
+            f"/admin/orgs/{winner_id}/merge/{loser_id}/",
+            headers=AUTH_HEADERS,
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+        async with db_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT address_id, address_type FROM entity_addresses"
+                " WHERE entity_type='organization' AND entity_id=$1",
+                winner_id,
+            )
+        assert len(rows) == 2
+        addr_ids = {r["address_id"] for r in rows}
+        assert shared_aid in addr_ids
+        assert unique_aid in addr_ids
+    finally:
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM entity_addresses WHERE entity_type='organization' AND entity_id=$1",
+                winner_id,
+            )
+            await conn.execute(
+                "DELETE FROM addresses WHERE id = ANY($1::text[])",
+                [shared_aid, unique_aid],
+            )
+            for oid in (winner_id, loser_id):
+                await conn.execute("DELETE FROM organization_names WHERE organization_id=$1", oid)
+                await conn.execute("DELETE FROM organizations WHERE id=$1", oid)

--- a/tests/api/admin/test_people_duplicates.py
+++ b/tests/api/admin/test_people_duplicates.py
@@ -1003,3 +1003,88 @@ async def test_merge_deduplicates_shared_person_address(client, db_pool):
             for pid in (winner_id, loser_id):
                 await conn.execute("DELETE FROM person_names WHERE person_id=$1", pid)
                 await conn.execute("DELETE FROM people WHERE id=$1", pid)
+
+
+# ---------------------------------------------------------------------------
+# contact_methods dedup during merge (#232 CR follow-up)
+# ---------------------------------------------------------------------------
+
+
+async def _add_person_contact(conn, person_id: str, value: str) -> str:
+    cm_id = generate_id()
+    await conn.execute(
+        "INSERT INTO contact_methods"
+        " (id, entity_type, entity_id, contact_type, value)"
+        " VALUES ($1, 'person', $2, 'phone', $3)",
+        cm_id,
+        person_id,
+        value,
+    )
+    return cm_id
+
+
+async def test_merge_reassigns_unique_person_contact(client, db_pool):
+    """Loser's contact method not on winner is transferred after merge."""
+    async with db_pool.acquire() as conn:
+        winner_id = await _make_person(conn, "Winner Person CM Test")
+        loser_id = await _make_person(conn, "Loser Person CM Test")
+        await _add_person_contact(conn, loser_id, "+13605550001")
+
+    try:
+        response = client.post(
+            f"/admin/people/{winner_id}/merge/{loser_id}/",
+            headers=AUTH_HEADERS,
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+        async with db_pool.acquire() as conn:
+            count = await conn.fetchval(
+                "SELECT count(*) FROM contact_methods WHERE entity_type='person' AND entity_id=$1",
+                winner_id,
+            )
+        assert count == 1
+    finally:
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM contact_methods WHERE entity_type='person' AND entity_id=$1",
+                winner_id,
+            )
+            for pid in (winner_id, loser_id):
+                await conn.execute("DELETE FROM person_names WHERE person_id=$1", pid)
+                await conn.execute("DELETE FROM people WHERE id=$1", pid)
+
+
+async def test_merge_deduplicates_shared_person_contact(client, db_pool):
+    """Shared contact (same type+value) on both people yields exactly one row on winner."""
+    async with db_pool.acquire() as conn:
+        winner_id = await _make_person(conn, "Winner Person CM Dedup Test")
+        loser_id = await _make_person(conn, "Loser Person CM Dedup Test")
+        await _add_person_contact(conn, winner_id, "+13605550100")
+        await _add_person_contact(conn, loser_id, "+13605550100")
+        await _add_person_contact(conn, loser_id, "+13605550200")
+
+    try:
+        response = client.post(
+            f"/admin/people/{winner_id}/merge/{loser_id}/",
+            headers=AUTH_HEADERS,
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+        async with db_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT value FROM contact_methods WHERE entity_type='person' AND entity_id=$1",
+                winner_id,
+            )
+        assert len(rows) == 2
+        assert {r["value"] for r in rows} == {"+13605550100", "+13605550200"}
+    finally:
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM contact_methods WHERE entity_type='person' AND entity_id=$1",
+                winner_id,
+            )
+            for pid in (winner_id, loser_id):
+                await conn.execute("DELETE FROM person_names WHERE person_id=$1", pid)
+                await conn.execute("DELETE FROM people WHERE id=$1", pid)

--- a/tests/api/admin/test_people_duplicates.py
+++ b/tests/api/admin/test_people_duplicates.py
@@ -853,3 +853,153 @@ async def test_legal_only_name_match_does_not_show_matched_via(
     assert response.status_code == 200
     assert "Peter Wimsey" in response.text
     assert "matched via: Harriet Vane" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# entity_addresses dedup during merge (#232)
+# ---------------------------------------------------------------------------
+
+
+async def _make_person(conn, name: str) -> str:
+    pid = generate_id()
+    await conn.execute("INSERT INTO people (id) VALUES ($1)", pid)
+    await conn.execute(
+        "INSERT INTO person_names (id, person_id, name, is_canonical) VALUES ($1, $2, $3, TRUE)",
+        generate_id(),
+        pid,
+        name,
+    )
+    return pid
+
+
+async def _add_person_address(
+    conn, person_id: str, raw_input: str, address_type: str = "mailing"
+) -> tuple[str, str]:
+    """Insert addresses + entity_addresses; return (address_id, entity_address_id)."""
+    aid = generate_id()
+    eaid = generate_id()
+    await conn.execute(
+        "INSERT INTO addresses (id, raw_input, country) VALUES ($1, $2, 'US')",
+        aid,
+        raw_input,
+    )
+    await conn.execute(
+        "INSERT INTO entity_addresses"
+        " (id, entity_type, entity_id, address_id, address_type)"
+        " VALUES ($1, 'person', $2, $3, $4)",
+        eaid,
+        person_id,
+        aid,
+        address_type,
+    )
+    return aid, eaid
+
+
+async def test_merge_reassigns_unique_person_address(client, db_pool):
+    """Loser's address not on winner is transferred to winner after merge."""
+    async with db_pool.acquire() as conn:
+        winner_id = await _make_person(conn, "Winner Person Addr Test")
+        loser_id = await _make_person(conn, "Loser Person Addr Test")
+        aid, _eaid = await _add_person_address(conn, loser_id, "100 Unique St")
+
+    try:
+        response = client.post(
+            f"/admin/people/{winner_id}/merge/{loser_id}/",
+            headers=AUTH_HEADERS,
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+        async with db_pool.acquire() as conn:
+            count = await conn.fetchval(
+                "SELECT count(*) FROM entity_addresses WHERE entity_type='person' AND entity_id=$1",
+                winner_id,
+            )
+        assert count == 1
+    finally:
+        async with db_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT address_id FROM entity_addresses"
+                " WHERE entity_type='person' AND entity_id=$1",
+                winner_id,
+            )
+            await conn.execute(
+                "DELETE FROM entity_addresses WHERE entity_type='person' AND entity_id=$1",
+                winner_id,
+            )
+            if rows:
+                await conn.execute(
+                    "DELETE FROM addresses WHERE id = ANY($1::text[])",
+                    [r["address_id"] for r in rows],
+                )
+            for pid in (winner_id, loser_id):
+                await conn.execute("DELETE FROM person_names WHERE person_id=$1", pid)
+                await conn.execute("DELETE FROM people WHERE id=$1", pid)
+
+
+async def test_merge_deduplicates_shared_person_address(client, db_pool):
+    """Shared address (same address_id + type) on both people yields one row on winner."""
+    async with db_pool.acquire() as conn:
+        winner_id = await _make_person(conn, "Winner Person Addr Dedup Test")
+        loser_id = await _make_person(conn, "Loser Person Addr Dedup Test")
+        # One address_id shared by both; loser also has a unique one.
+        shared_aid = generate_id()
+        await conn.execute(
+            "INSERT INTO addresses (id, raw_input, country) VALUES ($1, '100 Shared Ave', 'US')",
+            shared_aid,
+        )
+        for pid in (winner_id, loser_id):
+            await conn.execute(
+                "INSERT INTO entity_addresses"
+                " (id, entity_type, entity_id, address_id, address_type)"
+                " VALUES ($1, 'person', $2, $3, 'mailing')",
+                generate_id(),
+                pid,
+                shared_aid,
+            )
+        unique_aid = generate_id()
+        await conn.execute(
+            "INSERT INTO addresses (id, raw_input, country) VALUES ($1, '200 Unique Rd', 'US')",
+            unique_aid,
+        )
+        await conn.execute(
+            "INSERT INTO entity_addresses"
+            " (id, entity_type, entity_id, address_id, address_type)"
+            " VALUES ($1, 'person', $2, $3, 'physical')",
+            generate_id(),
+            loser_id,
+            unique_aid,
+        )
+
+    try:
+        response = client.post(
+            f"/admin/people/{winner_id}/merge/{loser_id}/",
+            headers=AUTH_HEADERS,
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+        async with db_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT address_id, address_type FROM entity_addresses"
+                " WHERE entity_type='person' AND entity_id=$1",
+                winner_id,
+            )
+        # Exactly 2: shared (mailing) deduplicated to one + unique (physical).
+        assert len(rows) == 2
+        addr_ids = {r["address_id"] for r in rows}
+        assert shared_aid in addr_ids
+        assert unique_aid in addr_ids
+    finally:
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM entity_addresses WHERE entity_type='person' AND entity_id=$1",
+                winner_id,
+            )
+            await conn.execute(
+                "DELETE FROM addresses WHERE id = ANY($1::text[])",
+                [shared_aid, unique_aid],
+            )
+            for pid in (winner_id, loser_id):
+                await conn.execute("DELETE FROM person_names WHERE person_id=$1", pid)
+                await conn.execute("DELETE FROM people WHERE id=$1", pid)


### PR DESCRIPTION
## Summary

- **`people_merge.py`**: adds dedup DELETE for `entity_addresses` before the bulk reassign loop — the same pattern `orgs_merge` received in the #230 CR follow-up. Without it, merging two people who share an `address_id + address_type` produces a duplicate row on the winner.
- **`schema.sql`**: migration appended after the `contact_methods` constraint block — cleans up any pre-existing FK-level duplicates, then adds `UNIQUE (entity_type, entity_id, address_type, address_id)` (`entity_addresses_entity_addr_uniq`). Normalised-form dedup (two separate `addresses` rows for the same physical address) remains handled at write time by `write_addresses()` via `COALESCE(standardized, raw_input)`.
- **`orgs_merge.py`**: removes the stale `#232 tracks…` comment.

## Test plan

- [ ] `test_merge_reassigns_unique_person_address` — loser's address not on winner is transferred (green before and after)
- [ ] `test_merge_deduplicates_shared_person_address` — shared `address_id+type` yields exactly one row on winner (red before fix, green after)
- [ ] Full merge integration suite: `pytest tests/api/admin/test_people_duplicates.py tests/api/admin/test_orgs_duplicates.py -m integration` — all pass
- [ ] `bash scripts/apply-schema.sh` on prod after merge

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)