### PR TITLE
#196 fix: consolidate per-model COUNT queries into a single UNION ALL

### DIFF
--- a/src/api/public/people.py
+++ b/src/api/public/people.py
@@ -333,14 +333,15 @@ async def _fetch_detail_arrays(
         """,
         person_id,
     )
-    voice_count = 0
-    for meta in registry.all():
-        if meta.is_queryable:
-            n = await db.fetchval(
-                # table_name is registry-controlled — not user input
-                f"SELECT COUNT(*) FROM {meta.table_name}"
-                " WHERE person_id = $1 AND archived_at IS NULL",
-                person_id,
-            )
-            voice_count += n or 0
+    queryable = [m for m in registry.all() if m.is_queryable]
+    if not queryable:
+        voice_count = 0
+    else:
+        # table_name values are registry-controlled — not user input
+        union_sql = " UNION ALL ".join(
+            f"SELECT COUNT(*) AS n FROM {m.table_name} WHERE person_id = $1 AND archived_at IS NULL"
+            for m in queryable
+        )
+        rows = await db.fetch(union_sql, person_id)
+        voice_count = sum(r["n"] for r in rows)
     return names, identifiers, voice_count

--- a/src/core/embedding_registry.py
+++ b/src/core/embedding_registry.py
@@ -2,7 +2,8 @@
 
 Loaded once at app startup from the ``embedding_model_registry`` table and
 stored in ``app.state.embedding_registry``.  Route handlers access it via the
-``get_embedding_registry`` FastAPI dependency, which can be overridden in tests.
+``_get_registry`` FastAPI dependency (defined per public router module), which
+can be overridden in tests via ``app.dependency_overrides``.
 """
 
 from dataclasses import dataclass

--- a/tests/api/public/test_embeddings.py
+++ b/tests/api/public/test_embeddings.py
@@ -8,6 +8,7 @@ import pytest
 import pytest_asyncio
 
 from src.api.main import app
+from src.api.public.people import _get_registry
 from src.core.db import generate_id
 from src.core.embedding_registry import EmbeddingRegistry, ModelMeta
 
@@ -448,7 +449,13 @@ def test_person_detail_voice_count_zero_for_no_embeddings(client, read_key, two_
 
 
 def test_person_detail_voice_count_sums_across_models(client, read_key, seeded_embeddings):
-    """voice_embeddings_count sums counts from all queryable models regardless of count."""
+    """voice_embeddings_count sums counts from all queryable models.
+
+    Both registry entries point at the same physical table (_TABLE) — a
+    same-table proxy, since only one real embeddings table exists. The DB-free
+    multi-table coverage lives in tests/api/public/test_people_detail_arrays.py.
+    pid0 has 3 rows in _TABLE, so the dual registry counts it twice → 3 + 3 = 6.
+    """
     pid0, _, _, _ = seeded_embeddings
 
     second_meta = ModelMeta(
@@ -462,15 +469,13 @@ def test_person_detail_voice_count_sums_across_models(client, read_key, seeded_e
     )
     dual = EmbeddingRegistry({_MODEL_ID: _FAKE_META, "second-test-model": second_meta})
 
-    saved = app.state.embedding_registry
-    app.state.embedding_registry = dual
+    app.dependency_overrides[_get_registry] = lambda: dual
     try:
         r = client.get(f"/api/v1/people/{pid0}", headers={"X-API-Key": read_key})
     finally:
-        app.state.embedding_registry = saved
+        app.dependency_overrides.pop(_get_registry, None)
 
     assert r.status_code == 200
-    # pid0 has 3 rows in _TABLE; dual registry queries the same table twice → 3+3=6
     assert r.json()["voice_embeddings_count"] == 6
 
 

--- a/tests/api/public/test_embeddings.py
+++ b/tests/api/public/test_embeddings.py
@@ -7,6 +7,7 @@ import random
 import pytest
 import pytest_asyncio
 
+from src.api.main import app
 from src.core.db import generate_id
 from src.core.embedding_registry import EmbeddingRegistry, ModelMeta
 
@@ -444,6 +445,33 @@ def test_person_detail_voice_count_zero_for_no_embeddings(client, read_key, two_
     r = client.get(f"/api/v1/people/{pid0}", headers={"X-API-Key": read_key})
     assert r.status_code == 200
     assert isinstance(r.json()["voice_embeddings_count"], int)
+
+
+def test_person_detail_voice_count_sums_across_models(client, read_key, seeded_embeddings):
+    """voice_embeddings_count sums counts from all queryable models regardless of count."""
+    pid0, _, _, _ = seeded_embeddings
+
+    second_meta = ModelMeta(
+        model_id="second-test-model",
+        table_name=_TABLE,
+        dimension=_DIM,
+        metric="cosine",
+        accepts_writes=False,
+        is_queryable=True,
+        operator="<=>",
+    )
+    dual = EmbeddingRegistry({_MODEL_ID: _FAKE_META, "second-test-model": second_meta})
+
+    saved = app.state.embedding_registry
+    app.state.embedding_registry = dual
+    try:
+        r = client.get(f"/api/v1/people/{pid0}", headers={"X-API-Key": read_key})
+    finally:
+        app.state.embedding_registry = saved
+
+    assert r.status_code == 200
+    # pid0 has 3 rows in _TABLE; dual registry queries the same table twice → 3+3=6
+    assert r.json()["voice_embeddings_count"] == 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/public/test_people_detail_arrays.py
+++ b/tests/api/public/test_people_detail_arrays.py
@@ -6,6 +6,8 @@ of round-trips regardless of how many queryable models the registry holds.
 
 from unittest.mock import AsyncMock
 
+import pytest
+
 from src.api.public.people import _fetch_detail_arrays
 from src.core.embedding_registry import EmbeddingRegistry, ModelMeta
 
@@ -22,31 +24,28 @@ def _meta(model_id: str, table_name: str) -> ModelMeta:
     )
 
 
-async def test_fetch_detail_arrays_single_round_trip_regardless_of_model_count():
+@pytest.mark.parametrize("n_models", [1, 3, 5])
+async def test_fetch_detail_arrays_single_round_trip_regardless_of_model_count(n_models):
     """Embedding counts collapse into one query — never one-per-model."""
     db = AsyncMock()
     db.fetch.return_value = []
 
     registry = EmbeddingRegistry(
-        {
-            "m1": _meta("m1", "person_embeddings_m1"),
-            "m2": _meta("m2", "person_embeddings_m2"),
-            "m3": _meta("m3", "person_embeddings_m3"),
-        }
+        {f"m{i}": _meta(f"m{i}", f"person_embeddings_m{i}") for i in range(n_models)}
     )
 
     await _fetch_detail_arrays("pid", db, registry)
 
     # names + identifiers + exactly one consolidated count query = 3 fetches,
-    # independent of the 3 queryable models. A regression to the per-model
-    # loop would bump this (or reintroduce fetchval calls) and fail here.
+    # independent of how many queryable models exist. A regression to the
+    # per-model loop would bump this (or reintroduce fetchval calls) and fail here.
     assert db.fetch.call_count == 3
     db.fetchval.assert_not_called()
 
     count_sql = db.fetch.call_args_list[-1].args[0]
-    assert count_sql.count("UNION ALL") == 2
-    for table in ("person_embeddings_m1", "person_embeddings_m2", "person_embeddings_m3"):
-        assert table in count_sql
+    assert count_sql.count("UNION ALL") == n_models - 1
+    for i in range(n_models):
+        assert f"person_embeddings_m{i}" in count_sql
 
 
 async def test_fetch_detail_arrays_no_count_query_when_no_queryable_models():

--- a/tests/api/public/test_people_detail_arrays.py
+++ b/tests/api/public/test_people_detail_arrays.py
@@ -1,0 +1,87 @@
+"""Unit tests for src.api.public.people._fetch_detail_arrays.
+
+Fast, DB-free tests that pin the embedding-count consolidation: a fixed number
+of round-trips regardless of how many queryable models the registry holds.
+"""
+
+from unittest.mock import AsyncMock
+
+from src.api.public.people import _fetch_detail_arrays
+from src.core.embedding_registry import EmbeddingRegistry, ModelMeta
+
+
+def _meta(model_id: str, table_name: str) -> ModelMeta:
+    return ModelMeta(
+        model_id=model_id,
+        table_name=table_name,
+        dimension=256,
+        metric="cosine",
+        accepts_writes=False,
+        is_queryable=True,
+        operator="<=>",
+    )
+
+
+async def test_fetch_detail_arrays_single_round_trip_regardless_of_model_count():
+    """Embedding counts collapse into one query — never one-per-model."""
+    db = AsyncMock()
+    db.fetch.return_value = []
+
+    registry = EmbeddingRegistry(
+        {
+            "m1": _meta("m1", "person_embeddings_m1"),
+            "m2": _meta("m2", "person_embeddings_m2"),
+            "m3": _meta("m3", "person_embeddings_m3"),
+        }
+    )
+
+    await _fetch_detail_arrays("pid", db, registry)
+
+    # names + identifiers + exactly one consolidated count query = 3 fetches,
+    # independent of the 3 queryable models. A regression to the per-model
+    # loop would bump this (or reintroduce fetchval calls) and fail here.
+    assert db.fetch.call_count == 3
+    db.fetchval.assert_not_called()
+
+    count_sql = db.fetch.call_args_list[-1].args[0]
+    assert count_sql.count("UNION ALL") == 2
+    for table in ("person_embeddings_m1", "person_embeddings_m2", "person_embeddings_m3"):
+        assert table in count_sql
+
+
+async def test_fetch_detail_arrays_no_count_query_when_no_queryable_models():
+    """Empty registry issues no count query and returns 0 (guards the empty-SQL branch)."""
+    db = AsyncMock()
+    db.fetch.return_value = []
+
+    _, _, voice_count = await _fetch_detail_arrays("pid", db, EmbeddingRegistry({}))
+
+    assert voice_count == 0
+    # Only names + identifiers — no count query, no per-model fetchval.
+    assert db.fetch.call_count == 2
+    db.fetchval.assert_not_called()
+
+
+async def test_fetch_detail_arrays_skips_non_queryable_models():
+    """Non-queryable models are excluded from the consolidated count query."""
+    db = AsyncMock()
+    db.fetch.return_value = []
+
+    queryable = _meta("m1", "person_embeddings_m1")
+    not_queryable = ModelMeta(
+        model_id="m2",
+        table_name="person_embeddings_m2",
+        dimension=256,
+        metric="cosine",
+        accepts_writes=False,
+        is_queryable=False,
+        operator="<=>",
+    )
+    registry = EmbeddingRegistry({"m1": queryable, "m2": not_queryable})
+
+    await _fetch_detail_arrays("pid", db, registry)
+
+    count_sql = db.fetch.call_args_list[-1].args[0]
+    assert "UNION ALL" not in count_sql
+    assert "person_embeddings_m1" in count_sql
+    assert "person_embeddings_m2" not in count_sql


### PR DESCRIPTION
## Summary

- Replaces the sequential `for meta in registry.all()` loop in `_fetch_detail_arrays` with a single `UNION ALL` query that counts all queryable model tables in one round-trip
- `asyncio.gather` was considered first but asyncpg rejects concurrent queries on a single connection; `UNION ALL` achieves the same O(1) round-trips without that constraint
- Adds `test_person_detail_voice_count_sums_across_models`: registers a second fake model pointing to the same real table, verifies the count sums correctly across both (3+3=6)

## Test plan

- [x] `test_person_detail_has_voice_embeddings_count` — existing single-model test, still passes
- [x] `test_person_detail_voice_count_sums_across_models` — new multi-model coverage, passes
- [x] Full `tests/api/public/test_embeddings.py` integration suite: 50/50 pass
- [x] Full unit suite: 644 passed, 3 skipped
- [x] All pre-commit hooks pass

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)