### PR TITLE
#240 Surface org `active` on public API via observation paradigm

### DIFF
--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -409,7 +409,7 @@ Upserts a person by identifier using the same match-or-create semantics as the o
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/api/v1/orgs/search` | API key | Search by display name or identifier. Params: `q`, `identifier_type` + `identifier_value` (takes precedence over `q`), `jurisdiction` (slug or ULID — filters to orgs with a `governing` affiliation for that jurisdiction), `include_archived`, `limit`, `offset`. |
-| `GET` | `/api/v1/orgs/{id}` | API key | Detail by ULID. Returns names, acronyms, identifiers, jurisdiction affiliations, `created_at`, and `updated_at`. ETag caching — see caching section above. |
+| `GET` | `/api/v1/orgs/{id}` | API key | Detail by ULID. Returns names, acronyms, identifiers, jurisdiction affiliations, `active`, `created_at`, and `updated_at`. ETag caching — see caching section above. |
 | `GET` | `/api/v1/orgs/{id}/events` | API key | Paginated lifecycle events for an organization. Params: `limit` (default 20, max 100), `offset`. Public-visibility and active events only. |
 | `POST` | `/api/v1/orgs/observations` | `observations:write` scope | Submit an organization identity observation. |
 
@@ -423,6 +423,7 @@ Returns the base search-result fields plus:
 | `acronyms` | Array of `{id, acronym, is_canonical}` |
 | `identifiers` | Array of `{id, type_id, type_slug, value}` |
 | `jurisdiction_affiliations` | Array of `{jurisdiction_id, affiliation_type: {id, slug, display_name}}`. Empty array when no affiliations exist. |
+| `active` | Boolean. Orgs-only domain axis: operationally live (`true`) vs. dissolved/defunct (`false`). **Orthogonal to `archived_at`** — an org can be `active` and archived, or inactive and not archived. Detail-only; not surfaced in search results. |
 | `created_at` | ISO 8601 UTC timestamp |
 | `updated_at` | ISO 8601 UTC timestamp |
 
@@ -453,6 +454,7 @@ Upserts an organization by identifier using the same match-or-create semantics a
 | `additional_identifiers` | optional | List of `{identifier_type_slug, identifier_value}` — for attaching secondary identifier schemes |
 | `jurisdiction_affiliations` | optional | List of `{jurisdiction_id, affiliation_type_slug}` — typed org-to-jurisdiction associations. `affiliation_type_slug` must match a value in `organization_jurisdiction_affiliation_types` (seeded values: `governing`, `registered`). Idempotent (duplicate rows silently ignored). Invalid `jurisdiction_id` or unknown `affiliation_type_slug` → `rejected`. |
 | `events` | optional | List of event claims — same shape as for `POST /people/observations`. See entity events section below. |
+| `active` | optional | Boolean. Sets the orgs-only `active` axis (operationally live vs. dissolved/defunct). **Omitted or `null` ⇒ the flag is left unchanged**; an explicit bool asserts it. Setting `active` on an **archived** org is rejected (`reason: active_on_archived_org`) — archiving is an admin lifecycle gate, so an archived row is not a valid observation target. A redundant assertion (value already matches) is a true no-op and emits no change-feed event. |
 
 **Disposition semantics:**
 
@@ -460,7 +462,7 @@ Upserts an organization by identifier using the same match-or-create semantics a
 |-------------|-----------|
 | `new` | Identifier not seen before; organization created |
 | `auto-attached` | Identifier already known; existing entity returned |
-| `rejected` | Unknown identifier type; identifier belongs to a non-organization entity; ambiguous parent lookup (0 or 2+ matches); DB constraint violation. A human-readable `reason` string is always present on rejected responses. |
+| `rejected` | Unknown identifier type; identifier belongs to a non-organization entity; ambiguous parent lookup (0 or 2+ matches); `active` asserted on an archived org (`reason: active_on_archived_org`); DB constraint violation. A human-readable `reason` string is always present on rejected responses. |
 
 **When to include `display_label`:** Add a label when the contact method serves a specific named function — e.g. `"Main Office"`, `"Committee Hotline"`, `"Press Inquiries"`. Omit it when the value alone is self-explanatory.
 

--- a/src/api/public/orgs.py
+++ b/src/api/public/orgs.py
@@ -30,6 +30,7 @@ from src.core.observation import (
     write_links,
     write_names,
     write_org_acronyms,
+    write_org_active,
     write_org_jurisdiction_affiliations,
     write_org_parent,
 )
@@ -86,6 +87,8 @@ async def submit_org_observation(
             await write_org_jurisdiction_affiliations(
                 db, entity_id, request.jurisdiction_affiliations
             )
+            if request.active is not None:
+                await write_org_active(db, entity_id, request.active)
     except ObservationRejected as exc:
         return ObservationResponse(disposition="rejected", reason=exc.detail)
     except IdentifierConflict as exc:
@@ -308,6 +311,7 @@ async def get_org(
             o.id,
             o.parent_id,
             o.archived_at,
+            o.active,
             o.created_at,
             o.updated_at,
             n.name,
@@ -339,6 +343,9 @@ async def get_org(
 
     return {
         **_org_row_to_dict(row),
+        # active is detail-only (#240) — added here, not in _org_row_to_dict
+        # (shared with search, whose queries do not select o.active).
+        "active": row["active"],
         "created_at": row["created_at"],
         "updated_at": row["updated_at"],
         "names": [dict(n) for n in names],

--- a/src/api/public/orgs.py
+++ b/src/api/public/orgs.py
@@ -63,6 +63,9 @@ async def submit_org_observation(
 
     try:
         async with db.transaction():
+            # Fail fast on an archived target before doing any write work (#240).
+            if request.active is not None:
+                await write_org_active(db, entity_id, request.active)
             await write_names(db, entity_id, entity_type, auth.key_id, request.names)
             await write_links(db, entity_id, entity_type, request.links)
             await write_contact_methods(db, entity_id, entity_type, request.contact_methods)
@@ -87,8 +90,6 @@ async def submit_org_observation(
             await write_org_jurisdiction_affiliations(
                 db, entity_id, request.jurisdiction_affiliations
             )
-            if request.active is not None:
-                await write_org_active(db, entity_id, request.active)
     except ObservationRejected as exc:
         return ObservationResponse(disposition="rejected", reason=exc.detail)
     except IdentifierConflict as exc:

--- a/src/api/public/schemas.py
+++ b/src/api/public/schemas.py
@@ -99,6 +99,9 @@ class OrgJurisdictionAffiliation(BaseModel):
 class OrgDetail(OrgSearchResult):
     """Full org record including name variants, acronyms, identifiers, and affiliations."""
 
+    # Orgs-only domain axis (#240): operationally live vs. dissolved/defunct.
+    # Orthogonal to archived_at. Detail-only — not surfaced in search results.
+    active: bool = True
     created_at: datetime
     updated_at: datetime
     names: list[OrgName] = Field(default_factory=list)
@@ -575,6 +578,9 @@ class OrganizationObservationRequest(BaseModel):
         default_factory=list
     )
     events: list[ObservationEventItem] = Field(default_factory=list)
+    # Orgs-only domain axis (#240). None/omitted ⇒ leave the flag unchanged;
+    # an explicit bool asserts it. Rejected when the target org is archived.
+    active: bool | None = None
 
     @model_validator(mode="after")
     def _xor_org_parent(self) -> "OrganizationObservationRequest":

--- a/src/api/public/schemas.py
+++ b/src/api/public/schemas.py
@@ -101,7 +101,9 @@ class OrgDetail(OrgSearchResult):
 
     # Orgs-only domain axis (#240): operationally live vs. dissolved/defunct.
     # Orthogonal to archived_at. Detail-only — not surfaced in search results.
-    active: bool = True
+    # Required (no default): the org row always supplies it, and a default would
+    # silently mask a handler that forgot to populate it.
+    active: bool
     created_at: datetime
     updated_at: datetime
     names: list[OrgName] = Field(default_factory=list)

--- a/src/core/observation.py
+++ b/src/core/observation.py
@@ -694,20 +694,22 @@ async def write_org_active(conn, organization_id: str, active: bool) -> None:
     valid observation target: archiving is an admin lifecycle gate, so asserting
     active on an archived row is treated as a malformed observation and rejected.
 
-    The UPDATE is guarded by ``active IS DISTINCT FROM`` so a redundant assertion
-    is a true no-op and does not fire fn_record_entity_change — preventing a
-    spurious 'updated' event in the change feed.
+    The row is locked (``FOR UPDATE``) so the archived check and the write are
+    atomic against a concurrent admin archive. The flag is written only when it
+    actually changes — a redundant assertion is a true no-op that does not fire
+    fn_record_entity_change, avoiding a spurious 'updated' event in the change
+    feed. The caller (resolve_entity) guarantees the org exists.
     """
-    row = await conn.fetchrow("SELECT archived_at FROM organizations WHERE id=$1", organization_id)
-    if row is None:
-        raise ObservationRejected(f"org_not_found: {organization_id!r}")
-    if row["archived_at"] is not None:
-        raise ObservationRejected("active_on_archived_org")
-    await conn.execute(
-        "UPDATE organizations SET active=$1 WHERE id=$2 AND active IS DISTINCT FROM $1",
-        active,
+    row = await conn.fetchrow(
+        "SELECT archived_at, active FROM organizations WHERE id=$1 FOR UPDATE",
         organization_id,
     )
+    if row["archived_at"] is not None:
+        raise ObservationRejected("active_on_archived_org")
+    if row["active"] != active:
+        await conn.execute(
+            "UPDATE organizations SET active=$1 WHERE id=$2", active, organization_id
+        )
 
 
 async def write_org_jurisdiction_affiliations(

--- a/src/core/observation.py
+++ b/src/core/observation.py
@@ -687,6 +687,29 @@ async def write_org_parent(conn, organization_id: str, parent_id: str) -> None:
     )
 
 
+async def write_org_active(conn, organization_id: str, active: bool) -> None:
+    """Set an organization's active flag from an observation (#240).
+
+    The active axis is orthogonal to archived_at, but an archived org is not a
+    valid observation target: archiving is an admin lifecycle gate, so asserting
+    active on an archived row is treated as a malformed observation and rejected.
+
+    The UPDATE is guarded by ``active IS DISTINCT FROM`` so a redundant assertion
+    is a true no-op and does not fire fn_record_entity_change — preventing a
+    spurious 'updated' event in the change feed.
+    """
+    row = await conn.fetchrow("SELECT archived_at FROM organizations WHERE id=$1", organization_id)
+    if row is None:
+        raise ObservationRejected(f"org_not_found: {organization_id!r}")
+    if row["archived_at"] is not None:
+        raise ObservationRejected("active_on_archived_org")
+    await conn.execute(
+        "UPDATE organizations SET active=$1 WHERE id=$2 AND active IS DISTINCT FROM $1",
+        active,
+        organization_id,
+    )
+
+
 async def write_org_jurisdiction_affiliations(
     conn, organization_id: str, affiliations: list
 ) -> None:

--- a/tests/api/public/test_observation_schemas.py
+++ b/tests/api/public/test_observation_schemas.py
@@ -245,6 +245,19 @@ def test_org_request_minimal_ok():
     assert req.organization_parent_id is None
 
 
+def test_org_request_active_defaults_none():
+    """active (#240) defaults to None — omitted means 'leave the flag unchanged'."""
+    req = OrganizationObservationRequest(identifier_type="org_ubi", identifier_value="999")
+    assert req.active is None
+
+
+def test_org_request_active_accepts_bool():
+    req = OrganizationObservationRequest(
+        identifier_type="org_ubi", identifier_value="999", active=False
+    )
+    assert req.active is False
+
+
 def test_org_request_acronyms_are_observation_acronym_objects():
     req = OrganizationObservationRequest(
         identifier_type="org_ubi",

--- a/tests/api/public/test_observations_orgs.py
+++ b/tests/api/public/test_observations_orgs.py
@@ -736,3 +736,145 @@ async def test_rejected_unknown_additional_identifier_includes_reason(client, or
     assert body["disposition"] == "rejected"
     assert body["reason"] is not None
     assert "zzz_bad_slug" in body["reason"]
+
+
+# ---------------------------------------------------------------------------
+# #240 — active flag via the observation paradigm (orgs-only)
+# ---------------------------------------------------------------------------
+
+
+async def test_observation_sets_active_false(client, org_write_key, db):
+    """active=False in an observation marks an existing org inactive."""
+    org_id = generate_id()
+    await db.execute("INSERT INTO organizations (id) VALUES ($1)", org_id)
+    try:
+        raw, _ = org_write_key
+        r = _post(
+            client,
+            raw,
+            {"identifier_type": "pm_org_id", "identifier_value": org_id, "active": False},
+        )
+        assert r.status_code == 200
+        assert r.json()["disposition"] == "auto-attached"
+        row = await db.fetchrow("SELECT active FROM organizations WHERE id=$1", org_id)
+        assert row["active"] is False
+    finally:
+        await db.execute("DELETE FROM organizations WHERE id=$1", org_id)
+
+
+async def test_observation_sets_active_true_reactivates(client, org_write_key, db):
+    """active=True in an observation reactivates a previously inactive org."""
+    org_id = generate_id()
+    await db.execute("INSERT INTO organizations (id, active) VALUES ($1, FALSE)", org_id)
+    try:
+        raw, _ = org_write_key
+        r = _post(
+            client,
+            raw,
+            {"identifier_type": "pm_org_id", "identifier_value": org_id, "active": True},
+        )
+        assert r.status_code == 200
+        assert r.json()["disposition"] == "auto-attached"
+        row = await db.fetchrow("SELECT active FROM organizations WHERE id=$1", org_id)
+        assert row["active"] is True
+    finally:
+        await db.execute("DELETE FROM organizations WHERE id=$1", org_id)
+
+
+async def test_observation_omitted_active_leaves_org_unchanged(client, org_write_key, db):
+    """An observation without an active field must not touch the flag."""
+    org_id = generate_id()
+    await db.execute("INSERT INTO organizations (id, active) VALUES ($1, FALSE)", org_id)
+    try:
+        raw, _ = org_write_key
+        r = _post(client, raw, {"identifier_type": "pm_org_id", "identifier_value": org_id})
+        assert r.status_code == 200
+        assert r.json()["disposition"] == "auto-attached"
+        row = await db.fetchrow("SELECT active FROM organizations WHERE id=$1", org_id)
+        assert row["active"] is False  # untouched
+    finally:
+        await db.execute("DELETE FROM organizations WHERE id=$1", org_id)
+
+
+async def test_observation_active_on_archived_org_rejected(client, org_write_key, db):
+    """Setting active on an archived org is a malformed observation → rejected."""
+    org_id = generate_id()
+    ubi_val = _unique_id()
+    await db.execute("INSERT INTO organizations (id, archived_at) VALUES ($1, NOW())", org_id)
+    ubi_type = await db.fetchrow("SELECT id FROM entity_identifier_types WHERE slug='org_ubi'")
+    assert ubi_type is not None, "org_ubi type not seeded — run apply_schema"
+    eid = generate_id()
+    await db.execute(
+        "INSERT INTO identifiers (id, entity_id, entity_identifier_type_id, value)"
+        " VALUES ($1,$2,$3,$4)",
+        eid,
+        org_id,
+        ubi_type["id"],
+        ubi_val,
+    )
+    try:
+        raw, _ = org_write_key
+        r = _post(
+            client,
+            raw,
+            {"identifier_type": "org_ubi", "identifier_value": ubi_val, "active": False},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["disposition"] == "rejected"
+        assert body["reason"] is not None
+        assert "archiv" in body["reason"].lower()
+        # The flag must remain untouched on rejection.
+        row = await db.fetchrow("SELECT active FROM organizations WHERE id=$1", org_id)
+        assert row["active"] is True
+    finally:
+        await db.execute("DELETE FROM identifiers WHERE id=$1", eid)
+        await db.execute("DELETE FROM organizations WHERE id=$1", org_id)
+
+
+async def test_observation_active_change_emits_entity_change(client, org_write_key, db):
+    """An effective active toggle appends exactly one entity_changes 'updated' row."""
+    org_id = generate_id()
+    await db.execute("INSERT INTO organizations (id) VALUES ($1)", org_id)
+    try:
+        before = await db.fetchval("SELECT COALESCE(MAX(id), 0) FROM entity_changes")
+        raw, _ = org_write_key
+        r = _post(
+            client,
+            raw,
+            {"identifier_type": "pm_org_id", "identifier_value": org_id, "active": False},
+        )
+        assert r.status_code == 200
+        rows = await db.fetch(
+            "SELECT change_kind FROM entity_changes"
+            " WHERE entity_id=$1 AND entity_type='organization' AND id > $2",
+            org_id,
+            before,
+        )
+        assert len(rows) == 1, f"expected 1 change row, got {len(rows)}"
+        assert rows[0]["change_kind"] == "updated"
+    finally:
+        await db.execute("DELETE FROM organizations WHERE id=$1", org_id)
+
+
+async def test_observation_active_noop_emits_no_entity_change(client, org_write_key, db):
+    """A redundant active assertion (value unchanged) emits no entity_changes row."""
+    org_id = generate_id()
+    await db.execute("INSERT INTO organizations (id, active) VALUES ($1, FALSE)", org_id)
+    try:
+        before = await db.fetchval("SELECT COALESCE(MAX(id), 0) FROM entity_changes")
+        raw, _ = org_write_key
+        r = _post(
+            client,
+            raw,
+            {"identifier_type": "pm_org_id", "identifier_value": org_id, "active": False},
+        )
+        assert r.status_code == 200
+        rows = await db.fetch(
+            "SELECT 1 FROM entity_changes WHERE entity_id=$1 AND id > $2",
+            org_id,
+            before,
+        )
+        assert len(rows) == 0, f"expected no change rows for a no-op, got {len(rows)}"
+    finally:
+        await db.execute("DELETE FROM organizations WHERE id=$1", org_id)

--- a/tests/api/public/test_observations_orgs.py
+++ b/tests/api/public/test_observations_orgs.py
@@ -832,6 +832,53 @@ async def test_observation_active_on_archived_org_rejected(client, org_write_key
         await db.execute("DELETE FROM organizations WHERE id=$1", org_id)
 
 
+async def test_observation_active_on_archived_org_is_atomic(client, org_write_key, db):
+    """An archived-org reject rolls back the whole observation — sibling writes too.
+
+    The active write runs first and rejects before any name write; the surrounding
+    transaction guarantees nothing (not even the names) is persisted.
+    """
+    org_id = generate_id()
+    ubi_val = _unique_id()
+    await db.execute("INSERT INTO organizations (id, archived_at) VALUES ($1, NOW())", org_id)
+    ubi_type = await db.fetchrow("SELECT id FROM entity_identifier_types WHERE slug='org_ubi'")
+    assert ubi_type is not None, "org_ubi type not seeded — run apply_schema"
+    eid = generate_id()
+    await db.execute(
+        "INSERT INTO identifiers (id, entity_id, entity_identifier_type_id, value)"
+        " VALUES ($1,$2,$3,$4)",
+        eid,
+        org_id,
+        ubi_type["id"],
+        ubi_val,
+    )
+    try:
+        raw, _ = org_write_key
+        r = _post(
+            client,
+            raw,
+            {
+                "identifier_type": "org_ubi",
+                "identifier_value": ubi_val,
+                "names": [{"name": "Should Not Persist Corp", "name_type": "legal"}],
+                "active": False,
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["disposition"] == "rejected"
+        # Nothing written: no name row, flag untouched.
+        name_count = await db.fetchval(
+            "SELECT COUNT(*) FROM organization_names WHERE organization_id=$1", org_id
+        )
+        assert name_count == 0, f"names must roll back on archived reject, found {name_count}"
+        active = await db.fetchval("SELECT active FROM organizations WHERE id=$1", org_id)
+        assert active is True
+    finally:
+        await db.execute("DELETE FROM organization_names WHERE organization_id=$1", org_id)
+        await db.execute("DELETE FROM identifiers WHERE id=$1", eid)
+        await db.execute("DELETE FROM organizations WHERE id=$1", org_id)
+
+
 async def test_observation_active_change_emits_entity_change(client, org_write_key, db):
     """An effective active toggle appends exactly one entity_changes 'updated' row."""
     org_id = generate_id()

--- a/tests/api/public/test_orgs.py
+++ b/tests/api/public/test_orgs.py
@@ -386,6 +386,44 @@ async def test_search_orgs_does_not_expose_timestamps(client, api_key, org_fixtu
 
 
 # ---------------------------------------------------------------------------
+# active flag (#240) — orgs-only domain axis, exposed on detail (read)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_get_org_detail_exposes_active_default_true(client, api_key, org_fixture):
+    """OrgDetail surfaces active; a fresh org defaults to active=True."""
+    oid = org_fixture["org_id"]
+    r = client.get(f"/api/v1/orgs/{oid}", headers={"X-API-Key": api_key})
+    assert r.status_code == 200
+    data = r.json()
+    assert "active" in data, "active missing from OrgDetail"
+    assert data["active"] is True
+
+
+@pytest.mark.integration
+async def test_get_org_detail_reflects_inactive(client, api_key, org_fixture, db):
+    """Setting active=FALSE is reflected in the detail payload."""
+    oid = org_fixture["org_id"]
+    await db.execute("UPDATE organizations SET active=FALSE WHERE id=$1", oid)
+    try:
+        r = client.get(f"/api/v1/orgs/{oid}", headers={"X-API-Key": api_key})
+        assert r.status_code == 200
+        assert r.json()["active"] is False
+    finally:
+        await db.execute("UPDATE organizations SET active=TRUE WHERE id=$1", oid)
+
+
+@pytest.mark.integration
+async def test_search_orgs_does_not_expose_active(client, api_key, org_fixture):
+    """active is a detail-only field; search results must not include it."""
+    r = _search(client, api_key, "Television")
+    assert r.status_code == 200
+    hit = next(o for o in r.json()["data"] if o["id"] == org_fixture["org_id"])
+    assert "active" not in hit
+
+
+# ---------------------------------------------------------------------------
 # Search — identifier_type / identifier_value filter
 # ---------------------------------------------------------------------------
 

--- a/tests/api/public/test_schemas.py
+++ b/tests/api/public/test_schemas.py
@@ -153,6 +153,18 @@ def test_org_detail_arrays_default_empty():
     assert detail.identifiers == []
 
 
+def test_org_detail_active_defaults_true():
+    """active (#240) is detail-only and defaults to True (matches DB default)."""
+    detail = OrgDetail(id="abc", created_at=_TS, updated_at=_TS)
+    assert detail.active is True
+    assert detail.model_dump(mode="json")["active"] is True
+
+
+def test_org_detail_active_round_trips_false():
+    detail = OrgDetail(id="abc", active=False, created_at=_TS, updated_at=_TS)
+    assert detail.model_dump(mode="json")["active"] is False
+
+
 def test_org_detail_full_record_shape():
     detail = OrgDetail(
         id="abc",

--- a/tests/api/public/test_schemas.py
+++ b/tests/api/public/test_schemas.py
@@ -2,6 +2,9 @@
 
 from datetime import UTC, datetime
 
+import pytest
+from pydantic import ValidationError
+
 from src.api.public.schemas import (
     OrgAcronym,
     OrgAffiliationType,
@@ -134,35 +137,40 @@ _TS = datetime(2024, 1, 1, tzinfo=UTC)
 
 
 def test_org_detail_inherits_archived_at_serializer():
-    detail = OrgDetail(id="abc", archived_at=_TS, created_at=_TS, updated_at=_TS)
+    detail = OrgDetail(id="abc", active=True, archived_at=_TS, created_at=_TS, updated_at=_TS)
     dumped = detail.model_dump(mode="json")
     assert dumped["archived_at"].endswith("Z")
 
 
 def test_org_detail_timestamps_serialized_to_z():
-    detail = OrgDetail(id="abc", created_at=_TS, updated_at=_TS)
+    detail = OrgDetail(id="abc", active=True, created_at=_TS, updated_at=_TS)
     dumped = detail.model_dump(mode="json")
     assert dumped["created_at"].endswith("Z")
     assert dumped["updated_at"].endswith("Z")
 
 
 def test_org_detail_arrays_default_empty():
-    detail = OrgDetail(id="abc", created_at=_TS, updated_at=_TS)
+    detail = OrgDetail(id="abc", active=True, created_at=_TS, updated_at=_TS)
     assert detail.names == []
     assert detail.acronyms == []
     assert detail.identifiers == []
 
 
-def test_org_detail_active_defaults_true():
-    """active (#240) is detail-only and defaults to True (matches DB default)."""
-    detail = OrgDetail(id="abc", created_at=_TS, updated_at=_TS)
-    assert detail.active is True
-    assert detail.model_dump(mode="json")["active"] is True
+def test_org_detail_active_is_required():
+    """active (#240) is required — no silent default masks a handler omission."""
+    with pytest.raises(ValidationError):
+        OrgDetail(id="abc", created_at=_TS, updated_at=_TS)
 
 
-def test_org_detail_active_round_trips_false():
-    detail = OrgDetail(id="abc", active=False, created_at=_TS, updated_at=_TS)
-    assert detail.model_dump(mode="json")["active"] is False
+def test_org_detail_active_round_trips():
+    true_dump = OrgDetail(id="abc", active=True, created_at=_TS, updated_at=_TS).model_dump(
+        mode="json"
+    )
+    false_dump = OrgDetail(id="abc", active=False, created_at=_TS, updated_at=_TS).model_dump(
+        mode="json"
+    )
+    assert true_dump["active"] is True
+    assert false_dump["active"] is False
 
 
 def test_org_detail_full_record_shape():
@@ -173,6 +181,7 @@ def test_org_detail_full_record_shape():
         slug="fc",
         parent_id=None,
         archived_at=None,
+        active=True,
         created_at=_TS,
         updated_at=_TS,
         names=[OrgName(id="n1", name="Foo Corp", name_type="legal", is_canonical=True)],
@@ -191,7 +200,7 @@ def test_org_detail_full_record_shape():
 
 
 def test_org_detail_jurisdiction_affiliations_default_empty():
-    detail = OrgDetail(id="abc", created_at=_TS, updated_at=_TS)
+    detail = OrgDetail(id="abc", active=True, created_at=_TS, updated_at=_TS)
     assert detail.jurisdiction_affiliations == []
 
 
@@ -200,6 +209,7 @@ def test_org_detail_jurisdiction_affiliations_shape():
     aff = OrgJurisdictionAffiliation(jurisdiction_id="jid1", affiliation_type=aff_type)
     detail = OrgDetail(
         id="abc",
+        active=True,
         created_at=_TS,
         updated_at=_TS,
         jurisdiction_affiliations=[aff],


### PR DESCRIPTION
Closes #240.

## Summary

Surfaces the orgs-only `active` axis (operationally live vs. dissolved/defunct) on the **public** API — readable on org detail and writable through the existing observation flow — so a system-of-record consumer (USA-WA) can mirror it. `active` is orthogonal to `archived_at`.

Per design review, the write **folds into the existing observation paradigm** — no new endpoint, no new scope.

## What changed

**Read**
- `OrgDetail.active` (`bool`, **required**) on `GET /api/v1/orgs/{id}`. Detail-only — deliberately not in search results (`OrgSearchResult`), so search queries are untouched.

**Write** — `POST /api/v1/orgs/observations`, `observations:write` scope
- Optional `active` field on `OrganizationObservationRequest`. Omitted/`null` ⇒ leave unchanged; explicit bool asserts it.
- `write_org_active` locks the row (`SELECT … FOR UPDATE`) so the archived check and write are atomic; **rejects** `active` on an archived org (`reason: active_on_archived_org`); writes only when the value changes, so a redundant assertion is a true no-op.
- Called first in the observation transaction → an archived target is rejected before any name/link write (atomic, no partial state).

**Feed**
- A real change rides the existing `fn_record_entity_change` trigger as `change_kind='updated'`; consumers re-fetch. A no-op emits nothing. No feed schema change.

**Docs**
- `docs/PUBLIC_API.md`: detail field, observation field, disposition reason.

## Tests

- Read: `active` exposed (T/F), absent from search.
- Write: sets false/true, omitted leaves unchanged, archived-org rejected, archived-reject is **atomic** (sibling name writes roll back).
- Feed: a change emits exactly one `updated`; a no-op emits none.
- Schema units: `active` required + round-trips; request defaults to `None`.

Full public suite: **504 passed**; `ruff check`/`format` clean; pre-ship (unit + JS) green.

## Follow-up

#241 — harmonize the **admin** active toggle with the same archived + no-op guards (pre-existing asymmetry, out of scope here).

## Commits
- `85116ec` feat — read + observation write + feed + docs
- `ec6059e` fix (CR r1) — required `active`, atomic `FOR UPDATE` + fail-fast
- `6eacfa4` test (CR r2) — archived-reject atomicity

🤖 Generated with [Claude Code](https://claude.com/claude-code)