### PR TITLE
#269 + #270: member role_type + org_wa_party identifier (WA legislator ingest enablers)

### DIFF
--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -509,9 +509,12 @@ Item fields: `id`, `slug`, `display_name`, `expects_jurisdiction`.
 - `slug` — the stable value sent as `RoleObservationRequest.role_type` and returned as `RoleDetail.role_type_slug`.
 - `expects_jurisdiction` — advisory hint that this office is normally attached with a `jurisdiction_id` (structural-tuple match). It is a producer hint, **not** enforced: `resolve_role` will let a jurisdiction-expecting type be used in title mode. Sending an **unknown** `role_type` is already rejected (`role_type_not_found`), so an unrecognized slug can never mint a role — this endpoint is what keeps a producer from sending a *valid-but-wrong* slug.
 
+`member` (#269) is the coarse, jurisdiction-less membership classifier (`expects_jurisdiction: false`) — "person is a member of this body/committee" beneath any precise seat. It is a classifier only: a role tagged `member` still matches by `(organization_id, lower(title))` (send a `title` like `"Member"`), and the type is stored on the role so memberships aggregate without relying on the free-text title.
+
 ```jsonc
 {
   "data": [
+    { "id": "01KX…03", "slug": "member",               "display_name": "Member",              "expects_jurisdiction": false },
     { "id": "01KX…01", "slug": "state_representative", "display_name": "State Representative", "expects_jurisdiction": true },
     { "id": "01KX…02", "slug": "state_senator",        "display_name": "State Senator",        "expects_jurisdiction": true }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.7.0"
+version = "0.8.0"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/backfill_org_wa_party_identifiers.py
+++ b/scripts/backfill_org_wa_party_identifiers.py
@@ -4,7 +4,7 @@ Issue #270: adds the ``org_wa_party`` entity_identifier_type so a producer can
 attach a WA party Org by a stable key instead of by name-match. The two party
 Orgs PM already holds (Democratic, Republican) predate the identifier, so a
 producer's first observation would create a duplicate unless we backfill. This
-script attaches the identifier to each, matched by canonical display name.
+script attaches the identifier to each, matched by canonical name.
 
 Value convention (#270): a bare lowercase party slug — ``democratic`` /
 ``republican``. No ``wa-`` prefix (the identifier *type* already scopes to WA).
@@ -12,11 +12,13 @@ Value convention (#270): a bare lowercase party slug — ``democratic`` /
 (an independent legislator = absence of a party Assignment), so there is nothing
 to backfill.
 
-Match safety: party Orgs are matched by canonical name via ``v_org_display_names``.
-Always run the dry run first and confirm each reported Org is the intended party
-before ``--execute`` — if PM's canonical names differ from the map below, update
-``_PARTY_ORG_NAMES`` (keys are compared lowercased). A name with no match, or
-more than one, is reported and skipped, never created.
+Match safety: party Orgs are matched on their canonical ``organization_names``
+row (not the ``v_org_display_names`` view, which composes "name (acronym)" and
+would miss an acronym'd Org). Always run the dry run first and confirm each
+reported Org is the intended party before ``--execute`` — if PM's canonical names
+differ from the map below, update ``_PARTY_ORG_NAMES`` (keys are compared
+lowercased). A name with no match, or more than one, is reported and skipped,
+never created.
 
 Idempotent — an Org that already carries the identifier is left untouched.
 
@@ -28,6 +30,8 @@ Usage:
 import argparse
 import asyncio
 import os
+from collections import Counter
+from typing import Literal, TypedDict
 
 import asyncpg
 
@@ -36,8 +40,10 @@ from src.core.logging import configure_logging, get_logger
 
 logger = get_logger(__name__)
 
-# Canonical display name (lowercased) -> party value. Keys are matched
-# case-insensitively against v_org_display_names.display_name.
+# Canonical name (lowercased) -> party value. Keys are matched case-insensitively
+# against an Org's canonical name. Match the canonical name row directly, not the
+# v_org_display_names view: that view composes "name (acronym)", so an acronym'd
+# party Org would silently fail an equality match.
 _PARTY_ORG_NAMES: dict[str, str] = {
     "washington state democratic party": "democratic",
     "washington state republican party": "republican",
@@ -45,9 +51,21 @@ _PARTY_ORG_NAMES: dict[str, str] = {
 
 _FIND_ORG_SQL = """
 SELECT organization_id
-FROM v_org_display_names
-WHERE lower(display_name) = $1
+FROM organization_names
+WHERE is_canonical = TRUE AND lower(name) = $1
 """
+
+PartyBackfillStatus = Literal["applied", "planned", "exists", "conflict", "missing", "ambiguous"]
+
+
+class PartyBackfillAction(TypedDict):
+    """One backfill outcome per mapped party value (see module docstring)."""
+
+    name: str
+    value: str
+    org_id: str | None
+    status: PartyBackfillStatus
+
 
 _EXISTING_VALUE_SQL = """
 SELECT i.value
@@ -62,12 +80,13 @@ VALUES ($1, $2, $3, $4)
 """
 
 
-async def backfill_party_identifiers(conn: asyncpg.Connection, *, execute: bool) -> list[dict]:
+async def backfill_party_identifiers(
+    conn: asyncpg.Connection, *, execute: bool
+) -> list[PartyBackfillAction]:
     """Attach org_wa_party identifiers to the mapped party Orgs.
 
-    Returns one action record per mapped party value:
-    ``{"name", "value", "org_id", "status"}`` where status is one of
-    ``applied`` (inserted), ``planned`` (dry run, would insert),
+    Returns one ``PartyBackfillAction`` per mapped party value, whose ``status``
+    is one of ``applied`` (inserted), ``planned`` (dry run, would insert),
     ``exists`` (already present with this value), ``conflict`` (already present
     with a different value — skipped), ``missing`` (no Org matched — skipped),
     or ``ambiguous`` (multiple Orgs matched — skipped). Only ``applied`` mutates.
@@ -78,7 +97,7 @@ async def backfill_party_identifiers(conn: asyncpg.Connection, *, execute: bool)
     if type_id is None:
         raise RuntimeError("org_wa_party identifier type not found — run apply_schema first")
 
-    actions: list[dict] = []
+    actions: list[PartyBackfillAction] = []
     for name, value in _PARTY_ORG_NAMES.items():
         org_ids = [r["organization_id"] for r in await conn.fetch(_FIND_ORG_SQL, name)]
 
@@ -138,12 +157,23 @@ async def run(*, execute: bool) -> None:
         else:
             actions = await backfill_party_identifiers(conn, execute=False)
 
-        applied = sum(1 for a in actions if a["status"] == "applied")
-        planned = sum(1 for a in actions if a["status"] == "planned")
+        # Surface every outcome, not just applied — a name mismatch shows up as
+        # missing/ambiguous here so a 0-applied run is never silently mistaken
+        # for "nothing to do".
+        counts = Counter(a["status"] for a in actions)
+        breakdown = ", ".join(f"{status}={n}" for status, n in sorted(counts.items()))
         if not execute:
-            logger.info("Dry run — %d identifier(s) would be attached; pass --execute", planned)
+            logger.info(
+                "Dry run — %d identifier(s) would be attached (%s); pass --execute",
+                counts["planned"],
+                breakdown or "no party Orgs mapped",
+            )
         else:
-            logger.info("Backfilled %d org_wa_party identifier(s)", applied)
+            logger.info(
+                "Backfilled %d org_wa_party identifier(s) (%s)",
+                counts["applied"],
+                breakdown or "no party Orgs mapped",
+            )
     finally:
         await conn.close()
 

--- a/scripts/backfill_org_wa_party_identifiers.py
+++ b/scripts/backfill_org_wa_party_identifiers.py
@@ -1,0 +1,164 @@
+"""Backfill org_wa_party identifiers onto the existing WA party Organizations.
+
+Issue #270: adds the ``org_wa_party`` entity_identifier_type so a producer can
+attach a WA party Org by a stable key instead of by name-match. The two party
+Orgs PM already holds (Democratic, Republican) predate the identifier, so a
+producer's first observation would create a duplicate unless we backfill. This
+script attaches the identifier to each, matched by canonical display name.
+
+Value convention (#270): a bare lowercase party slug — ``democratic`` /
+``republican``. No ``wa-`` prefix (the identifier *type* already scopes to WA).
+"Independent" is deliberately absent: PM does not model an Independent party Org
+(an independent legislator = absence of a party Assignment), so there is nothing
+to backfill.
+
+Match safety: party Orgs are matched by canonical name via ``v_org_display_names``.
+Always run the dry run first and confirm each reported Org is the intended party
+before ``--execute`` — if PM's canonical names differ from the map below, update
+``_PARTY_ORG_NAMES`` (keys are compared lowercased). A name with no match, or
+more than one, is reported and skipped, never created.
+
+Idempotent — an Org that already carries the identifier is left untouched.
+
+Usage:
+    uv run python -m scripts.backfill_org_wa_party_identifiers            # dry run
+    uv run python -m scripts.backfill_org_wa_party_identifiers --execute  # commit
+"""
+
+import argparse
+import asyncio
+import os
+
+import asyncpg
+
+from src.core.db import generate_id
+from src.core.logging import configure_logging, get_logger
+
+logger = get_logger(__name__)
+
+# Canonical display name (lowercased) -> party value. Keys are matched
+# case-insensitively against v_org_display_names.display_name.
+_PARTY_ORG_NAMES: dict[str, str] = {
+    "washington state democratic party": "democratic",
+    "washington state republican party": "republican",
+}
+
+_FIND_ORG_SQL = """
+SELECT organization_id
+FROM v_org_display_names
+WHERE lower(display_name) = $1
+"""
+
+_EXISTING_VALUE_SQL = """
+SELECT i.value
+FROM identifiers i
+JOIN entity_identifier_types t ON t.id = i.entity_identifier_type_id
+WHERE t.slug = 'org_wa_party' AND i.entity_id = $1
+"""
+
+_INSERT_SQL = """
+INSERT INTO identifiers (id, entity_id, entity_identifier_type_id, value)
+VALUES ($1, $2, $3, $4)
+"""
+
+
+async def backfill_party_identifiers(conn: asyncpg.Connection, *, execute: bool) -> list[dict]:
+    """Attach org_wa_party identifiers to the mapped party Orgs.
+
+    Returns one action record per mapped party value:
+    ``{"name", "value", "org_id", "status"}`` where status is one of
+    ``applied`` (inserted), ``planned`` (dry run, would insert),
+    ``exists`` (already present with this value), ``conflict`` (already present
+    with a different value — skipped), ``missing`` (no Org matched — skipped),
+    or ``ambiguous`` (multiple Orgs matched — skipped). Only ``applied`` mutates.
+    """
+    type_id = await conn.fetchval(
+        "SELECT id FROM entity_identifier_types WHERE slug = 'org_wa_party'"
+    )
+    if type_id is None:
+        raise RuntimeError("org_wa_party identifier type not found — run apply_schema first")
+
+    actions: list[dict] = []
+    for name, value in _PARTY_ORG_NAMES.items():
+        org_ids = [r["organization_id"] for r in await conn.fetch(_FIND_ORG_SQL, name)]
+
+        if not org_ids:
+            logger.warning("No Org matches canonical name %r — skipping %r", name, value)
+            actions.append({"name": name, "value": value, "org_id": None, "status": "missing"})
+            continue
+        if len(org_ids) > 1:
+            logger.warning(
+                "Ambiguous: %d Orgs match canonical name %r — skipping %r",
+                len(org_ids),
+                name,
+                value,
+            )
+            actions.append({"name": name, "value": value, "org_id": None, "status": "ambiguous"})
+            continue
+
+        org_id = org_ids[0]
+        existing = await conn.fetchval(_EXISTING_VALUE_SQL, org_id)
+        if existing is not None:
+            if existing == value:
+                status = "exists"
+            else:
+                logger.warning(
+                    "Org %s already has org_wa_party=%r, not overwriting with %r",
+                    org_id,
+                    existing,
+                    value,
+                )
+                status = "conflict"
+            actions.append({"name": name, "value": value, "org_id": org_id, "status": status})
+            continue
+
+        if execute:
+            await conn.execute(_INSERT_SQL, generate_id(), org_id, type_id, value)
+            logger.info("Attached org_wa_party=%r to Org %s (%r)", value, org_id, name)
+            status = "applied"
+        else:
+            logger.info("Would attach org_wa_party=%r to Org %s (%r)", value, org_id, name)
+            status = "planned"
+        actions.append({"name": name, "value": value, "org_id": org_id, "status": status})
+
+    return actions
+
+
+async def run(*, execute: bool) -> None:
+    """Connect to DATABASE_URL and backfill party identifiers."""
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL not set")
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        if execute:
+            async with conn.transaction():
+                actions = await backfill_party_identifiers(conn, execute=True)
+        else:
+            actions = await backfill_party_identifiers(conn, execute=False)
+
+        applied = sum(1 for a in actions if a["status"] == "applied")
+        planned = sum(1 for a in actions if a["status"] == "planned")
+        if not execute:
+            logger.info("Dry run — %d identifier(s) would be attached; pass --execute", planned)
+        else:
+            logger.info("Backfilled %d org_wa_party identifier(s)", applied)
+    finally:
+        await conn.close()
+
+
+def main() -> None:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Commit changes (default is dry run)",
+    )
+    args = parser.parse_args()
+    asyncio.run(run(execute=args.execute))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/observation.py
+++ b/src/core/observation.py
@@ -735,9 +735,14 @@ async def resolve_role(
         qualifier = None
 
     # NOTE: title-mode matching below keys on (org, lower(title)) and ignores
-    # role_type_id. Harmless today — role_type is only set on roles that carry a
-    # jurisdiction and take the jurisdiction-match branch. Revisit when typed
-    # roles without a jurisdiction (e.g. chamber leadership) are introduced.
+    # role_type_id — by design. Typed jurisdiction-less roles now exist (the
+    # `member` classifier, #269): role_type_id is persisted on create (below), so
+    # the classifier lands on the row and aggregates cleanly, but it is *not* a
+    # match key here — (org, title) stays the sole key, so a producer's emitter
+    # needs no change. One consequence: a pre-existing *untyped* role with the
+    # same (org, title) AUTO_ATTACHes and is left untyped (role_type_id not
+    # upgraded in place). Benign for greenfield ingest (fresh orgs); revisit with
+    # an upgrade-on-match if untyped duplicates of a typed role need reconciling.
 
     if jurisdiction_id is not None:
         existing = await conn.fetchrow(

--- a/src/core/schema.sql
+++ b/src/core/schema.sql
@@ -1389,7 +1389,7 @@ INSERT INTO entity_identifier_types (id, entity_type, slug, display_name, full_n
     -- WA political-party org identifier (#270): deterministic attach of a party
     -- Org by stable key (value convention: bare lowercase slug — democratic,
     -- republican). Existing party Orgs backfilled via a one-off script.
-    ('01KX0000000000000000000004', 'organization',    'org_wa_party',               'WA Party',       'Washington State Political Party',     FALSE),
+    ('01KWW0ZAM6C540AD40V48QBYJM', 'organization',    'org_wa_party',               'WA Party',       'Washington State Political Party',     FALSE),
     -- PM-native internal identifiers (#198): resolve directly by PM ULID, never NEW
     ('01KTVHGATRG3WEN9NXATTA2RA9', 'organization',    'pm_org_id',        'PM Org',        'Power Map Organization ID',             TRUE),
     ('01KTVHGATRG3WEN9NXATTA2RAA', 'person',          'pm_person_id',     'PM Person',     'Power Map Person ID',                   TRUE),

--- a/src/core/schema.sql
+++ b/src/core/schema.sql
@@ -1462,11 +1462,15 @@ END $$;
 
 -- Role-type classifier seed (#261). Extend as new offices are modeled
 -- (speaker, majority_leader, committee_chair, ...). expects_jurisdiction marks
--- an office normally attached with a jurisdiction (#268/#271) — both seeded
--- offices are; the upsert backfills it on existing rows.
+-- an office normally attached with a jurisdiction (#268/#271) — the two office
+-- rows are; the upsert backfills it on existing rows. `member` (#269) is the
+-- coarse, jurisdiction-less membership classifier (committee membership, or a
+-- chamber member whose precise seat isn't yet positionable) — expects_jurisdiction
+-- is FALSE; it attaches by (org, title) like any plain role.
 INSERT INTO role_types (id, slug, display_name, expects_jurisdiction) VALUES
     ('01KX0000000000000000000001', 'state_representative', 'State Representative', TRUE),
-    ('01KX0000000000000000000002', 'state_senator',        'State Senator',        TRUE)
+    ('01KX0000000000000000000002', 'state_senator',        'State Senator',        TRUE),
+    ('01KX0000000000000000000003', 'member',               'Member',               FALSE)
 ON CONFLICT (id) DO UPDATE SET
     slug                 = EXCLUDED.slug,
     display_name         = EXCLUDED.display_name,

--- a/src/core/schema.sql
+++ b/src/core/schema.sql
@@ -1386,6 +1386,10 @@ INSERT INTO entity_identifier_types (id, entity_type, slug, display_name, full_n
     -- WA legislature org identifier types (#225)
     ('01KVJWW7YCKYMY4ZEEZWPKZT5H', 'organization',    'org_wa_legislature_chamber', 'WA Chamber',     'Washington State Legislature Chamber', FALSE),
     ('01KVJWW7YCKYMY4ZEEZWPKZT5J', 'organization',    'org_wa_legislature',         'WA Legislature', 'Washington State Legislature',        FALSE),
+    -- WA political-party org identifier (#270): deterministic attach of a party
+    -- Org by stable key (value convention: bare lowercase slug — democratic,
+    -- republican). Existing party Orgs backfilled via a one-off script.
+    ('01KX0000000000000000000004', 'organization',    'org_wa_party',               'WA Party',       'Washington State Political Party',     FALSE),
     -- PM-native internal identifiers (#198): resolve directly by PM ULID, never NEW
     ('01KTVHGATRG3WEN9NXATTA2RA9', 'organization',    'pm_org_id',        'PM Org',        'Power Map Organization ID',             TRUE),
     ('01KTVHGATRG3WEN9NXATTA2RAA', 'person',          'pm_person_id',     'PM Person',     'Power Map Person ID',                   TRUE),

--- a/tests/api/public/test_role_types.py
+++ b/tests/api/public/test_role_types.py
@@ -76,6 +76,20 @@ async def test_role_types_seeded_offices_present_and_expect_jurisdiction(client,
 
 
 @pytest.mark.integration
+async def test_role_types_member_seeded_non_jurisdictional(client, api_key):
+    """The #269 `member` classifier is seeded with expects_jurisdiction=False.
+
+    Coarse body/committee membership (person is a member of a body, no precise
+    seat) — a jurisdiction-less classifier, so expects_jurisdiction must be False.
+    """
+    response = client.get("/api/v1/role-types", headers={"X-API-Key": api_key})
+    by_slug = {r["slug"]: r for r in response.json()["data"]}
+    assert "member" in by_slug
+    assert by_slug["member"]["display_name"] == "Member"
+    assert by_slug["member"]["expects_jurisdiction"] is False
+
+
+@pytest.mark.integration
 async def test_role_types_non_structural_defaults_false(client, api_key, db):
     """A role_type inserted without the flag surfaces expects_jurisdiction=false (default)."""
     rid = generate_id()

--- a/tests/core/test_resolve_role_structural.py
+++ b/tests/core/test_resolve_role_structural.py
@@ -311,3 +311,52 @@ async def test_structural_match_without_title_auto_attaches(db):
     assert disp1 is Disposition.NEW
     assert disp2 is Disposition.AUTO_ATTACHED
     assert id1 == id2
+
+
+# ---------------------------------------------------------------------------
+# Jurisdiction-less typed roles — the `member` classifier (#269)
+# ---------------------------------------------------------------------------
+
+
+async def test_member_role_persists_role_type_without_jurisdiction(db):
+    """A `member` role (no jurisdiction) is created with role_type_id set.
+
+    #269's contract: the classifier lands on the row (so memberships aggregate)
+    even though matching stays in title mode — the role carries no jurisdiction
+    and no qualifier.
+    """
+    org = await _org(db)
+    rid, disp, reason = await resolve_role(db, org, "Member", role_type="member")
+    assert disp is Disposition.NEW
+    assert reason is None
+    member_type_id = await db.fetchval("SELECT id FROM role_types WHERE slug='member'")
+    row = await db.fetchrow(
+        "SELECT role_type_id, jurisdiction_id, qualifier FROM roles WHERE id=$1", rid
+    )
+    assert row["role_type_id"] == member_type_id
+    assert row["jurisdiction_id"] is None
+    assert row["qualifier"] is None
+
+
+async def test_member_role_matches_by_title_not_jurisdiction_branch(db):
+    """A re-observed `member` role AUTO_ATTACHes by (org, lower(title))."""
+    org = await _org(db)
+    id1, disp1, _ = await resolve_role(db, org, "Member", role_type="member")
+    id2, disp2, _ = await resolve_role(db, org, "member", role_type="member")
+    assert disp1 is Disposition.NEW
+    assert disp2 is Disposition.AUTO_ATTACHED
+    assert id1 == id2
+
+
+async def test_typed_member_attaches_to_preexisting_untyped_title(db):
+    """(org, title) is the sole key: a `member` observation attaches to a
+    pre-existing untyped role of the same title (left untyped — documents the
+    resolve_role NOTE, #269)."""
+    org = await _org(db)
+    untyped_id, disp1, _ = await resolve_role(db, org, "Member")
+    typed_id, disp2, _ = await resolve_role(db, org, "Member", role_type="member")
+    assert disp1 is Disposition.NEW
+    assert disp2 is Disposition.AUTO_ATTACHED
+    assert typed_id == untyped_id
+    # The matched row keeps its NULL role_type_id (not upgraded in place).
+    assert await db.fetchval("SELECT role_type_id FROM roles WHERE id=$1", typed_id) is None

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -438,6 +438,16 @@ async def test_wa_legislature_identifier_types_seeded(db):
     }
 
 
+async def test_org_wa_party_identifier_type_seeded(db):
+    """The #270 org_wa_party identifier type is seeded (organization, public)."""
+    row = await db.fetchrow(
+        "SELECT entity_type, is_internal FROM entity_identifier_types WHERE slug = 'org_wa_party'"
+    )
+    assert row is not None, "org_wa_party not found — check seed data in schema.sql"
+    assert row["entity_type"] == "organization"
+    assert row["is_internal"] is False
+
+
 # ---------------------------------------------------------------------------
 # updated_at trigger
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_backfill_org_wa_party_identifiers.py
+++ b/tests/scripts/test_backfill_org_wa_party_identifiers.py
@@ -1,0 +1,98 @@
+"""Tests for scripts/backfill_org_wa_party_identifiers.py (#270).
+
+Backfills the ``org_wa_party`` identifier onto the two existing WA party Orgs
+(matched by canonical name) so a producer's first party observation
+AUTO_ATTACHES instead of creating a duplicate. Core logic takes an injected
+connection so tests run inside the rolled-back ``db`` transaction (mirrors
+tests/scripts/test_seed_roles.py).
+"""
+
+import pytest
+import pytest_asyncio
+
+from scripts.backfill_org_wa_party_identifiers import backfill_party_identifiers
+from src.core.db import generate_id
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def db(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            yield conn
+        finally:
+            await tr.rollback()
+
+
+async def _party_org(db, name: str) -> str:
+    """Create an org with the given canonical name; return its id."""
+    oid = generate_id()
+    await db.execute("INSERT INTO organizations (id) VALUES ($1)", oid)
+    await db.execute(
+        "INSERT INTO organization_names (id, organization_id, name, is_canonical)"
+        " VALUES ($1,$2,$3,TRUE)",
+        generate_id(),
+        oid,
+        name,
+    )
+    return oid
+
+
+async def _party_value(db, org_id: str) -> str | None:
+    return await db.fetchval(
+        "SELECT i.value FROM identifiers i"
+        " JOIN entity_identifier_types t ON t.id = i.entity_identifier_type_id"
+        " WHERE t.slug = 'org_wa_party' AND i.entity_id = $1",
+        org_id,
+    )
+
+
+async def test_backfill_attaches_party_identifiers_by_canonical_name(db):
+    dem = await _party_org(db, "Washington State Democratic Party")
+    rep = await _party_org(db, "Washington State Republican Party")
+
+    actions = await backfill_party_identifiers(db, execute=True)
+
+    assert await _party_value(db, dem) == "democratic"
+    assert await _party_value(db, rep) == "republican"
+    assert {a["value"]: a["status"] for a in actions} == {
+        "democratic": "applied",
+        "republican": "applied",
+    }
+
+
+async def test_backfill_is_idempotent(db):
+    dem = await _party_org(db, "Washington State Democratic Party")
+    rep = await _party_org(db, "Washington State Republican Party")
+
+    await backfill_party_identifiers(db, execute=True)
+    actions = await backfill_party_identifiers(db, execute=True)
+
+    assert {a["status"] for a in actions} == {"exists"}
+    count = await db.fetchval(
+        "SELECT count(*) FROM identifiers i"
+        " JOIN entity_identifier_types t ON t.id = i.entity_identifier_type_id"
+        " WHERE t.slug = 'org_wa_party' AND i.entity_id = ANY($1)",
+        [dem, rep],
+    )
+    assert count == 2
+
+
+async def test_backfill_dry_run_makes_no_changes(db):
+    dem = await _party_org(db, "Washington State Democratic Party")
+
+    actions = await backfill_party_identifiers(db, execute=False)
+
+    assert await _party_value(db, dem) is None
+    assert any(a["value"] == "democratic" and a["status"] == "planned" for a in actions)
+
+
+async def test_backfill_reports_missing_party_org(db):
+    """A party name with no matching Org is reported, never created."""
+    actions = await backfill_party_identifiers(db, execute=True)
+
+    by_value = {a["value"]: a["status"] for a in actions}
+    assert by_value == {"democratic": "missing", "republican": "missing"}

--- a/tests/scripts/test_backfill_org_wa_party_identifiers.py
+++ b/tests/scripts/test_backfill_org_wa_party_identifiers.py
@@ -41,6 +41,16 @@ async def _party_org(db, name: str) -> str:
     return oid
 
 
+async def _add_canonical_acronym(db, org_id: str, acronym: str) -> None:
+    await db.execute(
+        "INSERT INTO organization_acronyms (id, organization_id, acronym, is_canonical)"
+        " VALUES ($1,$2,$3,TRUE)",
+        generate_id(),
+        org_id,
+        acronym,
+    )
+
+
 async def _party_value(db, org_id: str) -> str | None:
     return await db.fetchval(
         "SELECT i.value FROM identifiers i"
@@ -96,3 +106,20 @@ async def test_backfill_reports_missing_party_org(db):
 
     by_value = {a["value"]: a["status"] for a in actions}
     assert by_value == {"democratic": "missing", "republican": "missing"}
+
+
+async def test_backfill_matches_acronymed_org_by_canonical_name(db):
+    """An Org with a canonical acronym still matches (regression guard).
+
+    v_org_display_names would render this Org as "Washington State Democratic
+    Party (WSDP)"; matching on that composed display name would miss it. The
+    backfill keys on the canonical name row directly, so the acronym is
+    irrelevant and the identifier still attaches.
+    """
+    dem = await _party_org(db, "Washington State Democratic Party")
+    await _add_canonical_acronym(db, dem, "WSDP")
+
+    actions = await backfill_party_identifiers(db, execute=True)
+
+    assert await _party_value(db, dem) == "democratic"
+    assert {a["value"]: a["status"] for a in actions}["democratic"] == "applied"

--- a/uv.lock
+++ b/uv.lock
@@ -526,7 +526,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Two small, independent enablers for usa-wa's WA-legislator ingest (usa-wa#27 / P1b). Bundled in one branch; one commit per issue.

## #269 — `member` role_type
Seeds a `member` classifier (`expects_jurisdiction=FALSE`) — coarse committee / un-positioned chamber membership beneath a precise seat.
- Classifier only: a `member` role still matches by `(organization_id, lower(title))`; `role_type_id` is persisted on create, so memberships aggregate without leaning on the free-text title. **No emitter change needed** on the producer side.
- Refreshed the now-live NOTE in `resolve_role` (typed jurisdiction-less roles now exist) and documented `member` in `PUBLIC_API.md`.
- Note: the issue's `is_seat=false` is stale — #271 renamed that column to `expects_jurisdiction`.

## #270 — `org_wa_party` identifier type
Lets a producer attach a WA party Org by a stable key instead of the fragile name-match cascade, mirroring `org_wa_pdc` / `org_wa_legislature_*`.
- **Value convention:** bare lowercase party slug — `democratic` / `republican` (no `wa-` prefix; the type already scopes to WA).
- Idempotent, dry-run-gated `scripts/backfill_org_wa_party_identifiers.py` attaches the identifier to the two existing WA party Orgs (matched by canonical name) so the producer's first observation AUTO_ATTACHES instead of duplicating. **Operator must run the dry run and confirm the matched Orgs before `--execute`** — if PM's canonical names differ, adjust `_PARTY_ORG_NAMES`.
- **No Independent party Org** is created — validated that PM has zero party-specific modeling, so an independent legislator = absence of a party Assignment.

## Deferred (noted on #269)
The optional positionless-seat reject (defense-in-depth for #267) — via a `role_types.requires_qualifier` flag — is intentionally **not** in this PR; `member` already lets the producer stop emitting positionless seats. Tracking as a follow-up.

## Testing
- New: `test_role_types_member_seeded_non_jurisdictional`, `test_org_wa_party_identifier_type_seeded`, + 4 backfill tests.
- Full suite green: **885 unit passed**, **2020 integration passed** (2 skipped). Ruff + pre-commit clean.

Closes #269
Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
