### PR TITLE
fix: widen person names actions column for the Cite button

### DIFF
--- a/src/templates/admin/people/detail.html
+++ b/src/templates/admin/people/detail.html
@@ -61,7 +61,10 @@
           <th scope="col">Name</th>
           <th scope="col" style="text-align:right;width:6rem">Type</th>
           <th scope="col" style="text-align:right;width:6rem">Canonical</th>
-          <th scope="col" style="width:9rem"></th>
+          <!-- Actions: wide enough for Cite + Edit + Delete on one line (#319).
+               14rem cleared the buttons by only ~9px under table-layout:fixed +
+               2rem cell padding; 15rem gives headroom for font-rendering variance. -->
+          <th scope="col" style="width:15rem"></th>
         </tr></thead>
         <tbody>
           {% for n in names %}


### PR DESCRIPTION
The person names table is `table-layout:fixed` with the actions column pinned at `9rem` — sized for two buttons (Edit/Delete). #319 added a third (**Cite**), overflowing the fixed width and clipping "Delete" at every viewport width. Widen to `15rem`. Org names aren't citable, so their table is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)