### PR TITLE
fix: style citations panel + closable inline drawer + entity-scoped ids

### DIFF
--- a/src/api/admin/_citations_shared.py
+++ b/src/api/admin/_citations_shared.py
@@ -96,7 +96,11 @@ def make_citations_router(
                 entity_type,
                 entity_id,
             )
-            return templates.TemplateResponse(request, _PANEL, _ctx(entity_id, citations=citations))
+            # dismissible=True → the panel renders a Close control (this route is
+            # the inline drawer target for person_name / entity_event rows).
+            return templates.TemplateResponse(
+                request, _PANEL, _ctx(entity_id, citations=citations, dismissible=True)
+            )
 
     def _validate(field_name: str | None, url: str | None, title: str | None) -> str | None:
         if field_name is not None and field_name not in CITABLE_FIELDS.get(

--- a/src/api/admin/jurisdictions.py
+++ b/src/api/admin/jurisdictions.py
@@ -481,6 +481,7 @@ async def jurisdiction_detail(
             "affiliations": affiliations,
             "roles": roles,
             "citations": citations,
+            "entity_id": jurisdiction_id,
             "cit_base": f"/jurisdictions/{jurisdiction_id}/citations",
             "citable_fields": sorted(CITABLE_FIELDS["jurisdiction"]),
             "flash_msg": flash_msg,

--- a/src/api/admin/orgs.py
+++ b/src/api/admin/orgs.py
@@ -522,6 +522,7 @@ async def org_detail(
             "roles": roles,
             "events": events,
             "citations": citations,
+            "entity_id": org_id,
             "cit_base": f"/orgs/{org_id}/citations",
             "citable_fields": sorted(CITABLE_FIELDS["organization"]),
             "org_ended_on": org_ended_on,

--- a/src/api/admin/people.py
+++ b/src/api/admin/people.py
@@ -326,6 +326,7 @@ async def person_detail(
             "role_assignments": role_assignments,
             "events": events,
             "citations": citations,
+            "entity_id": person_id,
             "cit_base": f"/people/{person_id}/citations",
             "citable_fields": sorted(CITABLE_FIELDS["person"]),
             "embeddings": embeddings,

--- a/src/api/admin/role_assignments.py
+++ b/src/api/admin/role_assignments.py
@@ -284,6 +284,7 @@ async def ra_detail(
             "links": links,
             "identifiers": identifiers,
             "citations": citations,
+            "entity_id": ra_id,
             "cit_base": f"/role-assignments/{ra_id}/citations",
             "citable_fields": sorted(CITABLE_FIELDS["role_assignment"]),
             "flash_msg": flash_msg,

--- a/src/api/admin/roles.py
+++ b/src/api/admin/roles.py
@@ -314,6 +314,7 @@ async def role_detail(
             "phone_contacts": phone_contacts,
             "links": links,
             "citations": citations,
+            "entity_id": role_id,
             "cit_base": f"/roles/{role_id}/citations",
             "citable_fields": sorted(CITABLE_FIELDS["role"]),
             "flash_msg": flash_msg,

--- a/src/templates/admin/citations/partials/_citation_form_row.html
+++ b/src/templates/admin/citations/partials/_citation_form_row.html
@@ -1,6 +1,6 @@
 {# admin/citations/partials/_citation_form_row.html — shared create/edit form (#319) #}
 {% set f = form if form is defined else None %}
-<tr id="{% if c %}citation-row-{{ c.id }}{% else %}citation-row-new{% endif %}">
+<tr id="{% if c %}citation-row-{{ c.id }}{% else %}citation-row-new-{{ entity_id }}{% endif %}">
   <td colspan="4" style="padding:var(--space-2) var(--space-4)">
     <form {% if c %}
           hx-post="/admin{{ cit_base }}/{{ c.id }}/edit-row/"
@@ -8,7 +8,7 @@
           hx-swap="outerHTML"
           {% else %}
           hx-post="/admin{{ cit_base }}/"
-          hx-target="#citation-row-new"
+          hx-target="#citation-row-new-{{ entity_id }}"
           hx-swap="outerHTML"
           {% endif %}
           style="display:grid;gap:var(--space-2)">
@@ -44,9 +44,9 @@
         <div class="form-group" style="margin-bottom:0;flex:2;min-width:12rem">
           <label>Excerpt
             <input type="text" name="excerpt" placeholder="Supporting quote (optional)"
-                   aria-describedby="citation-excerpt-opt-{% if c %}{{ c.id }}{% else %}new{% endif %}"
+                   aria-describedby="citation-excerpt-opt-{% if c %}{{ c.id }}{% else %}new-{{ entity_id }}{% endif %}"
                    value="{{ (f.excerpt if f else (c.excerpt if c else '')) or '' }}">
-            <span class="visually-hidden" id="citation-excerpt-opt-{% if c %}{{ c.id }}{% else %}new{% endif %}">Optional</span>
+            <span class="visually-hidden" id="citation-excerpt-opt-{% if c %}{{ c.id }}{% else %}new-{{ entity_id }}{% endif %}">Optional</span>
           </label>
         </div>
         <div style="display:flex;gap:var(--space-2);margin-left:auto;white-space:nowrap">

--- a/src/templates/admin/citations/partials/_citations_panel.html
+++ b/src/templates/admin/citations/partials/_citations_panel.html
@@ -1,35 +1,52 @@
 {# admin/citations/partials/_citations_panel.html — shared citations section (#319)
 
    Context: cit_base (e.g. /people/{id}/citations), citable_fields, entity_id,
-   citations (list of rows). Include from any entity detail page. #}
-<section class="card" aria-labelledby="citations-heading">
+   citations (list of rows). Include from any entity detail page. When loaded into
+   an inline drawer (a person_name / entity_event row's "Cite" button), the route
+   passes dismissible=True so the panel renders a Close control. #}
+<section class="entity-section" aria-labelledby="citations-heading-{{ entity_id }}">
   <div style="display:flex;justify-content:space-between;align-items:center;gap:var(--space-2)">
-    <h2 id="citations-heading" style="margin:0">
+    <h2 id="citations-heading-{{ entity_id }}" style="margin:0">
       <span aria-hidden="true">📚</span> Citations
-      {% if citations %}<span class="badge">{{ citations | length }}</span>{% endif %}
+      {% if citations %}<span class="badge badge--neutral">{{ citations | length }}</span>{% endif %}
     </h2>
-    <button type="button" class="btn btn--sm btn--primary"
-            hx-get="/admin{{ cit_base }}/new-row/"
-            hx-target="#citation-row-new"
-            hx-swap="outerHTML">Add citation</button>
-  </div>
-  <table class="table" style="margin-top:var(--space-3)">
-    <thead>
-      <tr>
-        <th scope="col">Source</th>
-        <th scope="col">Field</th>
-        <th scope="col">Excerpt</th>
-        <th scope="col" style="text-align:right">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for c in citations %}
-      {% include "admin/citations/partials/_citation_row.html" %}
-      {% endfor %}
-      <tr id="citation-row-new"></tr>
-      {% if not citations %}
-      <tr id="citations-empty"><td colspan="4" style="color:var(--color-text-muted)">No citations yet.</td></tr>
+    <div style="display:flex;gap:var(--space-2);white-space:nowrap">
+      {# Guarded add (add-row-guard.js opts in via data-new-row-id); prepends the
+         form into this panel's own tbody so multiple panels on one page don't
+         collide and repeated adds work (matches the names/events pattern). #}
+      <button type="button" class="btn btn--sm btn--primary"
+              data-new-row-id="citation-row-new-{{ entity_id }}"
+              hx-get="/admin{{ cit_base }}/new-row/"
+              hx-target="#citations-tbody-{{ entity_id }}"
+              hx-swap="afterbegin"
+              hx-sync="this:drop">Add citation</button>
+      {% if dismissible %}
+      <button type="button" class="btn btn--sm btn--secondary"
+              aria-label="Close citations panel"
+              onclick="this.closest('section').remove()">Close</button>
       {% endif %}
-    </tbody>
-  </table>
+    </div>
+  </div>
+  <div class="table-wrapper" style="margin-top:var(--space-3)">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th scope="col">Source</th>
+          <th scope="col" style="width:8rem">Field</th>
+          <th scope="col">Excerpt</th>
+          <th scope="col" style="width:9rem"></th>
+        </tr>
+      </thead>
+      <tbody id="citations-tbody-{{ entity_id }}">
+        {% for c in citations %}
+        {% include "admin/citations/partials/_citation_row.html" %}
+        {% endfor %}
+        {% if not citations %}
+        <tr id="citations-empty-{{ entity_id }}">
+          <td colspan="4" style="color:var(--color-text-muted)">No citations yet.</td>
+        </tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
 </section>

--- a/tests/api/admin/test_citations.py
+++ b/tests/api/admin/test_citations.py
@@ -140,6 +140,10 @@ async def test_detail_page_shows_citations_panel(client, db, person):
     assert r.status_code == 200
     assert "Citations" in r.text
     assert "Panel Src" in r.text
+    # The permanent detail-page panel is not dismissible (no Close control).
+    assert "Close citations panel" not in r.text
+    # entity_id must reach the panel so its ids are entity-scoped (no empty suffix).
+    assert f'id="citations-tbody-{person}"' in r.text
 
 
 async def _seed_org(db) -> tuple[str, str]:
@@ -238,10 +242,14 @@ async def _seed_event(db) -> str:
 
 async def test_person_name_inline_panel_and_create(client, db):
     nid = await _seed_name(db)
-    # Inline panel GET renders the shared panel.
+    # Inline panel GET renders the shared panel — styled with admin classes and,
+    # because it's the inline drawer, a Close control (#319 styling fix).
     p = await client.get(f"/admin/person-names/{nid}/citations/", headers=AUTH)
     assert p.status_code == 200
     assert "Citations" in p.text
+    assert 'class="entity-section"' in p.text  # not the non-existent "card"
+    assert 'class="data-table"' in p.text  # not the non-existent "table"
+    assert "Close citations panel" in p.text  # dismissible
     # Create a name-scoped citation.
     r = await client.post(
         f"/admin/person-names/{nid}/citations/",


### PR DESCRIPTION
Follow-up to #319. The citations panel used CSS classes (`card`/`table`) that aren't in the admin design system, so it rendered unstyled on every detail page; the inline person_name/entity_event "Cite" drawer had no close control; and a hardcoded `citation-row-new` id collided across the multiple citation panels that can appear on one page.

- `entity-section` + `data-table` (in `table-wrapper`) + `badge--neutral`.
- Dismissible **Close** control on the inline drawer (`dismissible=True` from the panel route).
- Entity-scope the new-row / tbody / heading ids; adopt the guarded `afterbegin` add-row pattern (matches names/events) so repeated adds work and panels don't collide.
- Pass `entity_id` into all five detail-page panel contexts (caught by live-rendering the page).

Verified by rendering the real Jinkins page. 1056 unit + 191 detail-page integration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)