### PR TITLE
#319 fix: scope name/event citation drawer to its row + lock field

### DIFF
--- a/src/api/admin/_citations_shared.py
+++ b/src/api/admin/_citations_shared.py
@@ -44,7 +44,9 @@ def make_citations_router(
     entity_not_found_msg: str,
     detail_url: Callable[[str], str],
     redirect_resolver: Callable[[str, Any], Awaitable[str]] | None = None,
+    subject_resolver: Callable[[str, Any], Awaitable[str | None]] | None = None,
     inline_panel: bool = False,
+    locked_field: str | None = None,
 ) -> APIRouter:
     """Return a configured citations APIRouter for the given entity type.
 
@@ -55,8 +57,19 @@ def make_citations_router(
     → owning entity) whose parent isn't derivable from the id alone. When absent,
     the sync ``detail_url`` is used.
 
+    ``subject_resolver`` (optional) resolves a human label for the panel heading
+    ("Citations for …") so a sub-entity drawer names what it cites and can never be
+    confused with the owning entity's own panel.
+
     ``inline_panel=True`` registers a ``GET /`` route rendering the whole citations
-    panel for one entity — the lazy-load target for a sub-entity's expandable row.
+    panel for one entity — the lazy-load target for a sub-entity's expandable row;
+    it renders as a full-width sub-row so it nests under the clicked parent row.
+
+    ``locked_field`` (optional) pins every citation on this entity to a single
+    field (e.g. ``"name"`` for person_name, whose only citable field is the name
+    itself): the form drops the field picker and the server ignores any posted
+    ``field_name``. Prevents a name/event drawer from silently minting a
+    whole-record citation that reads as redundant with the owner's panel (#319).
     """
     router = APIRouter(prefix=prefix, tags=tags)
     citable_fields = sorted(CITABLE_FIELDS.get(entity_type, frozenset()))
@@ -76,6 +89,7 @@ def make_citations_router(
             "entity_id": entity_id,
             "cit_base": prefix.replace("{entity_id}", entity_id),
             "citable_fields": citable_fields,
+            "locked_field": locked_field,
             **extra,
         }
 
@@ -96,10 +110,20 @@ def make_citations_router(
                 entity_type,
                 entity_id,
             )
-            # dismissible=True → the panel renders a Close control (this route is
-            # the inline drawer target for person_name / entity_event rows).
+            subject_label = await subject_resolver(entity_id, db) if subject_resolver else None
+            # dismissible=True → Close control; as_subrow=True → the panel is wrapped
+            # as a full-width table row so it nests directly under the clicked
+            # person_name / entity_event row (tethered, not a bottom drawer, #319).
             return templates.TemplateResponse(
-                request, _PANEL, _ctx(entity_id, citations=citations, dismissible=True)
+                request,
+                _PANEL,
+                _ctx(
+                    entity_id,
+                    citations=citations,
+                    dismissible=True,
+                    as_subrow=True,
+                    subject_label=subject_label,
+                ),
             )
 
     def _validate(field_name: str | None, url: str | None, title: str | None) -> str | None:
@@ -134,7 +158,7 @@ def make_citations_router(
     ):
         await _get_entity_or_404(entity_id, db)
         f_field, f_url, f_title, f_excerpt = (
-            _clean(field_name),
+            locked_field or _clean(field_name),
             _clean(url),
             _clean(title),
             _clean(excerpt),
@@ -248,7 +272,7 @@ def make_citations_router(
         if not existing:
             raise HTTPException(status_code=404)
         f_field, f_url, f_title, f_excerpt = (
-            _clean(field_name),
+            locked_field or _clean(field_name),
             _clean(url),
             _clean(title),
             _clean(excerpt),

--- a/src/api/admin/entity_event_citations.py
+++ b/src/api/admin/entity_event_citations.py
@@ -19,6 +19,17 @@ async def _resolve_owner(event_id: str, db) -> str:
     return f"/admin/{base}/{row['entity_id']}/"
 
 
+async def _event_subject(event_id: str, db) -> str | None:
+    # Heading label for the inline drawer: the event type name.
+    name = await db.fetchval(
+        "SELECT t.display_name FROM entity_events e"
+        " JOIN entity_event_types t ON t.id = e.event_type_id"
+        " WHERE e.id=$1",
+        event_id,
+    )
+    return f"{name} event" if name else None
+
+
 router = make_citations_router(
     entity_type="entity_event",
     prefix="/entity-events/{entity_id}/citations",
@@ -27,5 +38,7 @@ router = make_citations_router(
     entity_not_found_msg="Event not found",
     detail_url=lambda eid: "/admin/",
     redirect_resolver=_resolve_owner,
+    subject_resolver=_event_subject,
     inline_panel=True,
+    # Events keep the field picker — date / place / notes are all citable.
 )

--- a/src/api/admin/people_name_citations.py
+++ b/src/api/admin/people_name_citations.py
@@ -15,6 +15,16 @@ async def _resolve_person(name_id: str, db) -> str:
     return f"/admin/people/{pid}/" if pid else "/admin/people/"
 
 
+async def _name_subject(name_id: str, db) -> str | None:
+    # Heading label for the inline drawer. Admin curates every name (the names
+    # table already shows non-public rows with a visibility badge), so no display
+    # filter here — allow-listed in tests/core/test_visible_names_filter.py.
+    row = await db.fetchrow("SELECT name, name_type FROM person_names WHERE id=$1", name_id)
+    if not row:
+        return None
+    return f'"{row["name"]}" ({row["name_type"]})'
+
+
 router = make_citations_router(
     entity_type="person_name",
     prefix="/person-names/{entity_id}/citations",
@@ -23,5 +33,8 @@ router = make_citations_router(
     entity_not_found_msg="Name not found",
     detail_url=lambda eid: "/admin/people/",
     redirect_resolver=_resolve_person,
+    subject_resolver=_name_subject,
     inline_panel=True,
+    # A name citation is inherently about the name — no field picker, always 'name'.
+    locked_field="name",
 )

--- a/src/static/admin/admin.css
+++ b/src/static/admin/admin.css
@@ -245,6 +245,13 @@ a:hover { color: var(--color-brand-hover); }
 .data-table tr.is-inactive td:first-child { color: var(--color-inactive); }
 .col--date { min-width: 8rem; white-space: nowrap; }
 
+/* Citations sub-row: a name/event row's "Cite" button expands its panel here,
+   nested directly beneath the clicked row (#319). Tint + inset it so it reads as
+   a child of that row rather than a peer, and never let :hover lift the tint. */
+.data-table tr.citations-subrow td,
+.data-table tr.citations-subrow:hover td { background: var(--color-surface-alt); padding: var(--space-3) var(--space-3) var(--space-3) var(--space-5); }
+.data-table tr.citations-subrow .entity-section { margin: 0; }
+
 .entity-card { background: var(--color-surface-1); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-5); margin-bottom: var(--space-5); }
 .entity-card__title { margin: 0 0 var(--space-4); font-size: var(--font-size-lg); font-weight: 700; }
 .entity-card__actions { display: flex; justify-content: flex-end; margin-bottom: var(--space-3); }

--- a/src/templates/admin/citations/partials/_citation_form_row.html
+++ b/src/templates/admin/citations/partials/_citation_form_row.html
@@ -16,6 +16,11 @@
       <div class="alert alert--error" role="alert">{{ error }}</div>
       {% endif %}
       <div style="display:flex;gap:var(--space-2);flex-wrap:wrap;align-items:end">
+        {% if locked_field %}
+        {# Field is pinned (e.g. a name citation is always about the name) — no
+           picker; the server ignores any posted field_name regardless. #}
+        <input type="hidden" name="field_name" value="{{ locked_field }}">
+        {% else %}
         <div class="form-group" style="margin-bottom:0">
           <label>Field
             <select name="field_name" aria-label="Cited field">
@@ -27,6 +32,7 @@
             </select>
           </label>
         </div>
+        {% endif %}
         <div class="form-group" style="margin-bottom:0;flex:1;min-width:16rem">
           <label>URL
             <input type="url" name="url" placeholder="https://source.example/…"

--- a/src/templates/admin/citations/partials/_citations_panel.html
+++ b/src/templates/admin/citations/partials/_citations_panel.html
@@ -3,11 +3,14 @@
    Context: cit_base (e.g. /people/{id}/citations), citable_fields, entity_id,
    citations (list of rows). Include from any entity detail page. When loaded into
    an inline drawer (a person_name / entity_event row's "Cite" button), the route
-   passes dismissible=True so the panel renders a Close control. #}
+   passes dismissible=True (renders a Close control), as_subrow=True (wraps the
+   panel as a full-width table row so it nests under the clicked parent row), and
+   subject_label (heading names what is being cited). #}
+{% if as_subrow %}<tr class="citations-subrow" id="citations-subrow-{{ entity_id }}"><td colspan="99">{% endif %}
 <section class="entity-section" aria-labelledby="citations-heading-{{ entity_id }}">
   <div style="display:flex;justify-content:space-between;align-items:center;gap:var(--space-2)">
     <h2 id="citations-heading-{{ entity_id }}" style="margin:0">
-      <span aria-hidden="true">📚</span> Citations
+      <span aria-hidden="true">📚</span> Citations{% if subject_label %} <span style="font-weight:400;color:var(--color-text-muted)">for {{ subject_label }}</span>{% endif %}
       {% if citations %}<span class="badge badge--neutral">{{ citations | length }}</span>{% endif %}
     </h2>
     <div style="display:flex;gap:var(--space-2);white-space:nowrap">
@@ -50,3 +53,4 @@
     </table>
   </div>
 </section>
+{% if as_subrow %}</td></tr>{% endif %}

--- a/src/templates/admin/orgs/detail.html
+++ b/src/templates/admin/orgs/detail.html
@@ -144,8 +144,6 @@
       </tbody>
     </table>
   </div>
-  {# Inline citations drawer for an event row's "Cite" button (#319). #}
-  <div id="events-citations-drawer"></div>
 </section>
 
 {% include "admin/citations/partials/_citations_panel.html" %}

--- a/src/templates/admin/people/detail.html
+++ b/src/templates/admin/people/detail.html
@@ -76,9 +76,6 @@
         </tbody>
       </table>
     </div>
-    {# Inline citations drawer: a name row's "Cite" button hx-loads that name's
-       citations panel here (#319). One open at a time. #}
-    <div id="names-citations-drawer"></div>
 
     {% include "admin/people/partials/_pronouns_read.html" %}
 
@@ -115,9 +112,6 @@
       </tbody>
     </table>
   </div>
-  {# Inline citations drawer: an event row's "Cite" button hx-loads that event's
-     citations panel here (#319). #}
-  <div id="events-citations-drawer"></div>
 </section>
 
 {% include "admin/citations/partials/_citations_panel.html" %}

--- a/src/templates/admin/people/partials/_name_row.html
+++ b/src/templates/admin/people/partials/_name_row.html
@@ -40,11 +40,14 @@
   <td style="text-align:right">{{ n.name_type }}</td>
   <td style="text-align:right">{% if n.is_canonical %}<span class="badge badge--active">Yes</span>{% else %}—{% endif %}</td>
   <td style="text-align:right;white-space:nowrap">
+    {# Panel expands as a sub-row directly beneath this name row (tethered, #319).
+       Wipe any open citations sub-row first so only one is open at a time. #}
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Citations for name {{ n.name }}"
             hx-get="/admin/person-names/{{ n.id }}/citations/"
-            hx-target="#names-citations-drawer"
-            hx-swap="innerHTML">Cite</button>
+            hx-target="#name-row-{{ n.id }}"
+            hx-swap="afterend"
+            hx-on:htmx:before-request="document.querySelectorAll('tr.citations-subrow').forEach(function(e){e.remove()})">Cite</button>
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Edit name {{ n.name }}"
             hx-get="/admin/people/{{ person_id }}/names/{{ n.id }}/edit-row/"

--- a/src/templates/admin/shared/_event_row.html
+++ b/src/templates/admin/shared/_event_row.html
@@ -48,11 +48,14 @@
     {% endif %}
   </td>
   <td style="text-align:right;white-space:nowrap">
+    {# Panel expands as a sub-row directly beneath this event row (tethered, #319).
+       Wipe any open citations sub-row first so only one is open at a time. #}
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Citations for {{ ev.event_type_name }} event"
             hx-get="/admin/entity-events/{{ ev.id }}/citations/"
-            hx-target="#events-citations-drawer"
-            hx-swap="innerHTML">Cite</button>
+            hx-target="#{{ _ev_row_prefix }}-{{ ev.id }}"
+            hx-swap="afterend"
+            hx-on:htmx:before-request="document.querySelectorAll('tr.citations-subrow').forEach(function(e){e.remove()})">Cite</button>
     {% if not ev.archived_at %}
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Edit {{ ev.event_type_name }} event"

--- a/tests/api/admin/test_citations.py
+++ b/tests/api/admin/test_citations.py
@@ -140,8 +140,10 @@ async def test_detail_page_shows_citations_panel(client, db, person):
     assert r.status_code == 200
     assert "Citations" in r.text
     assert "Panel Src" in r.text
-    # The permanent detail-page panel is not dismissible (no Close control).
+    # The permanent detail-page panel is not dismissible (no Close control) and
+    # renders as a plain section, never a nested sub-row (that is drawer-only).
     assert "Close citations panel" not in r.text
+    assert "citations-subrow" not in r.text
     # entity_id must reach the panel so its ids are entity-scoped (no empty suffix).
     assert f'id="citations-tbody-{person}"' in r.text
 
@@ -316,8 +318,57 @@ async def test_name_and_event_rows_show_cite_button(client, db):
     r = await client.get(f"/admin/people/{pid}/", headers=AUTH)
     assert r.status_code == 200
     assert f"/admin/person-names/{nid}/citations/" in r.text
-    assert 'id="names-citations-drawer"' in r.text
-    assert 'id="events-citations-drawer"' in r.text
+    # The Cite button tethers the panel to its own row (afterend), not a shared
+    # bottom drawer — the drawer divs are gone (#319 scoping fix).
+    assert f'hx-target="#name-row-{nid}"' in r.text
+    assert 'hx-swap="afterend"' in r.text
+    assert 'id="names-citations-drawer"' not in r.text
+    assert 'id="events-citations-drawer"' not in r.text
+
+
+async def test_person_name_panel_is_scoped_labeled_subrow(client, db):
+    nid = await _seed_name(db)  # name "Jo", type legal
+    p = await client.get(f"/admin/person-names/{nid}/citations/", headers=AUTH)
+    assert p.status_code == 200
+    # Rendered as a full-width sub-row so it nests under the clicked name row.
+    assert "citations-subrow" in p.text
+    assert 'colspan="99"' in p.text
+    # Heading names the subject so it can't be confused with the person panel.
+    assert "Jo" in p.text
+    assert "for" in p.text  # "Citations for …"
+
+
+async def test_person_name_new_row_locks_field(client, db):
+    nid = await _seed_name(db)
+    r = await client.get(f"/admin/person-names/{nid}/citations/new-row/", headers=AUTH)
+    assert r.status_code == 200
+    # No field picker on a name citation — it is always about the name.
+    assert 'name="field_name"' in r.text
+    assert "<select" not in r.text
+    assert 'type="hidden" name="field_name" value="name"' in r.text
+
+
+async def test_person_name_create_forces_locked_field(client, db):
+    nid = await _seed_name(db)
+    # Even if a rogue client posts a different field_name, the server pins it.
+    r = await client.post(
+        f"/admin/person-names/{nid}/citations/",
+        headers=HTMX,
+        data={"field_name": "notes", "url": "https://s/x"},
+    )
+    assert r.status_code == 200, r.text
+    row = await db.fetchrow(
+        "SELECT * FROM citations WHERE entity_type='person_name' AND entity_id=$1", nid
+    )
+    assert row["field_name"] == "name"
+
+
+async def test_entity_event_new_row_keeps_field_selector(client, db):
+    eid = await _seed_event(db)
+    r = await client.get(f"/admin/entity-events/{eid}/citations/new-row/", headers=AUTH)
+    assert r.status_code == 200
+    # Events have multiple citable fields → the selector is legitimate.
+    assert '<select name="field_name"' in r.text
 
 
 # ── sub-entity delete drops its citations (no orphan) ─────────────────────────


### PR DESCRIPTION
## Summary
Follow-up polish on the #319 citations UI. The sub-entity **Cite** drawer (on person-name and event rows) reused the top-level entity panel verbatim, loading into a shared bottom drawer with a whole-record field picker — so it read as disjoint from the row you clicked and could mint a citation that looked redundant with the owning entity's own Citations panel.

## Changes
- **Tethered.** The panel now expands as a full-width **sub-row directly beneath the clicked name/event row** (`as_subrow`, `colspan=99`, tinted + inset), one open at a time — mirroring in-place Edit rather than a bottom drawer. Drawer `<div>`s removed from people/orgs detail; Cite buttons target their own row + `afterend`.
- **Labeled.** Heading names the subject — *Citations for "Laurie Jinkins" (legal)* — via a `subject_resolver`, so it can't be confused with the owner's panel.
- **Field-locked.** `person_name` citations pin to `field_name='name'` (`locked_field`): no field picker, and the server ignores any posted `field_name`. Events keep their picker (date/place/notes are all citable).

## Verification
- New/updated tests in `tests/api/admin/test_citations.py` (subrow render, scoped heading, locked field UI + server enforcement, event picker retained, tethering, detail panel is-not-a-subrow). 22 admin citation tests + 164 people/org/event/name integration tests green; full pre-ship suite (Python + JS) green.
- Live-rendered against the real Laurie Jinkins record: Cite tethers to `#name-row-…`, panel is a scoped `citations-subrow` with Close, name form has no picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)