### PR TITLE
#319 fix: exact colspan on citation sub-row (fix names-table scrunch)

### DIFF
--- a/src/api/admin/_citations_shared.py
+++ b/src/api/admin/_citations_shared.py
@@ -47,6 +47,7 @@ def make_citations_router(
     subject_resolver: Callable[[str, Any], Awaitable[str | None]] | None = None,
     inline_panel: bool = False,
     locked_field: str | None = None,
+    subrow_colspan: int = 1,
 ) -> APIRouter:
     """Return a configured citations APIRouter for the given entity type.
 
@@ -70,6 +71,11 @@ def make_citations_router(
     itself): the form drops the field picker and the server ignores any posted
     ``field_name``. Prevents a name/event drawer from silently minting a
     whole-record citation that reads as redundant with the owner's panel (#319).
+
+    ``subrow_colspan`` must equal the parent table's exact column count when
+    ``inline_panel`` is used (person_name → 4, entity_event → 6). It is NOT a
+    "span everything" sentinel: an over-large value implies phantom columns that
+    collapse the real ones under ``table-layout:fixed`` (#319 scrunch regression).
     """
     router = APIRouter(prefix=prefix, tags=tags)
     citable_fields = sorted(CITABLE_FIELDS.get(entity_type, frozenset()))
@@ -90,6 +96,7 @@ def make_citations_router(
             "cit_base": prefix.replace("{entity_id}", entity_id),
             "citable_fields": citable_fields,
             "locked_field": locked_field,
+            "subrow_colspan": subrow_colspan,
             **extra,
         }
 

--- a/src/api/admin/entity_event_citations.py
+++ b/src/api/admin/entity_event_citations.py
@@ -41,4 +41,6 @@ router = make_citations_router(
     subject_resolver=_event_subject,
     inline_panel=True,
     # Events keep the field picker — date / place / notes are all citable.
+    # Events table columns: Type / Date / Place / Linked Entity / Status / actions.
+    subrow_colspan=6,
 )

--- a/src/api/admin/people_name_citations.py
+++ b/src/api/admin/people_name_citations.py
@@ -37,4 +37,6 @@ router = make_citations_router(
     inline_panel=True,
     # A name citation is inherently about the name — no field picker, always 'name'.
     locked_field="name",
+    # Names table columns: Name / Type / Canonical / actions.
+    subrow_colspan=4,
 )

--- a/src/templates/admin/citations/partials/_citations_panel.html
+++ b/src/templates/admin/citations/partials/_citations_panel.html
@@ -6,7 +6,7 @@
    passes dismissible=True (renders a Close control), as_subrow=True (wraps the
    panel as a full-width table row so it nests under the clicked parent row), and
    subject_label (heading names what is being cited). #}
-{% if as_subrow %}<tr class="citations-subrow" id="citations-subrow-{{ entity_id }}"><td colspan="99">{% endif %}
+{% if as_subrow %}<tr class="citations-subrow" id="citations-subrow-{{ entity_id }}"><td colspan="{{ subrow_colspan }}">{% endif %}
 <section class="entity-section" aria-labelledby="citations-heading-{{ entity_id }}">
   <div style="display:flex;justify-content:space-between;align-items:center;gap:var(--space-2)">
     <h2 id="citations-heading-{{ entity_id }}" style="margin:0">

--- a/tests/api/admin/test_citations.py
+++ b/tests/api/admin/test_citations.py
@@ -332,10 +332,24 @@ async def test_person_name_panel_is_scoped_labeled_subrow(client, db):
     assert p.status_code == 200
     # Rendered as a full-width sub-row so it nests under the clicked name row.
     assert "citations-subrow" in p.text
-    assert 'colspan="99"' in p.text
+    # colspan must equal the names table's exact column count (Name/Type/Canonical/
+    # actions = 4). An over-large colspan (e.g. 99) implies phantom columns that
+    # collapse the real ones under table-layout:fixed (#319 scrunch regression).
+    assert 'colspan="4"' in p.text
+    assert 'colspan="99"' not in p.text
     # Heading names the subject so it can't be confused with the person panel.
     assert "Jo" in p.text
     assert "for" in p.text  # "Citations for …"
+
+
+async def test_entity_event_panel_subrow_spans_events_table(client, db):
+    eid = await _seed_event(db)
+    p = await client.get(f"/admin/entity-events/{eid}/citations/", headers=AUTH)
+    assert p.status_code == 200
+    assert "citations-subrow" in p.text
+    # Events table has 6 columns (Type/Date/Place/Linked/Status/actions).
+    assert 'colspan="6"' in p.text
+    assert 'colspan="99"' not in p.text
 
 
 async def test_person_name_new_row_locks_field(client, db):


### PR DESCRIPTION
## Summary
Regression fix for the #338 inline citation sub-row. The panel wrapper used `colspan="99"` as a "span everything" value, but that makes the browser treat the table as having **99 columns**. Under the names table's `table-layout:fixed`, leftover width is split across the 96 phantom columns, collapsing the real **Name** column — the "scrunched" Names section.

## Fix
- New `subrow_colspan` param on `make_citations_router`, set to the parent table's exact column count: `person_name=4` (Name/Type/Canonical/actions), `entity_event=6` (Type/Date/Place/Linked/Status/actions). Template spans that instead of 99.

## Verification
- New/updated tests assert the exact colspan (4 for names, 6 for events) and that `colspan="99"` is gone. 23 admin citation tests + full pre-ship suite (Python + JS) green.
- Live-rendered: served name panel emits `colspan="4"` matching the 4-column names table, zero `colspan="99"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)