### PR TITLE
#319 fix: Close removes the whole citation sub-row (no lingering footer)

### DIFF
--- a/src/templates/admin/citations/partials/_citations_panel.html
+++ b/src/templates/admin/citations/partials/_citations_panel.html
@@ -24,9 +24,11 @@
               hx-swap="afterbegin"
               hx-sync="this:drop">Add citation</button>
       {% if dismissible %}
+      {# Remove the whole sub-row when inline (else its empty tr lingers as a
+         trailing footer strip); fall back to the section for a non-subrow panel. #}
       <button type="button" class="btn btn--sm btn--secondary"
               aria-label="Close citations panel"
-              onclick="this.closest('section').remove()">Close</button>
+              onclick="(this.closest('tr.citations-subrow') || this.closest('section')).remove()">Close</button>
       {% endif %}
     </div>
   </div>

--- a/tests/api/admin/test_citations.py
+++ b/tests/api/admin/test_citations.py
@@ -340,6 +340,9 @@ async def test_person_name_panel_is_scoped_labeled_subrow(client, db):
     # Heading names the subject so it can't be confused with the person panel.
     assert "Jo" in p.text
     assert "for" in p.text  # "Citations for …"
+    # Close must remove the whole sub-row, not just the inner <section> — else an
+    # empty tr lingers as a trailing footer strip (#319 regression).
+    assert "tr.citations-subrow" in p.text
 
 
 async def test_entity_event_panel_subrow_spans_events_table(client, db):


### PR DESCRIPTION
## Summary
Closing the inline citations sub-panel left a trailing empty footer strip. The **Close** button ran `this.closest('section').remove()`, which removed only the inner `<section>` and left its wrapping `<tr class="citations-subrow"><td>` behind as an empty row.

## Fix
Close now removes the whole sub-row when inline — `(this.closest('tr.citations-subrow') || this.closest('section')).remove()` — falling back to the section for a non-subrow panel.

## Verification
Test asserts the served Close handler targets `tr.citations-subrow`; 23 admin citation tests + full pre-ship suite green. Live-rendered handler confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)