### PR TITLE
#319 CR: citations UI polish — empty-state, colspan guard, toggle, locked-field column, JS extraction

### DIFF
--- a/src/api/admin/_citations_shared.py
+++ b/src/api/admin/_citations_shared.py
@@ -77,6 +77,12 @@ def make_citations_router(
     "span everything" sentinel: an over-large value implies phantom columns that
     collapse the real ones under ``table-layout:fixed`` (#319 scrunch regression).
     """
+    if inline_panel and subrow_colspan < 2:
+        raise ValueError(
+            "inline_panel routers must set subrow_colspan to the parent table's"
+            f" column count (>=2); got {subrow_colspan} for {entity_type}."
+        )
+
     router = APIRouter(prefix=prefix, tags=tags)
     citable_fields = sorted(CITABLE_FIELDS.get(entity_type, frozenset()))
 
@@ -213,10 +219,12 @@ def make_citations_router(
         row = await db.fetchrow("SELECT * FROM citations WHERE id=$1", cid)
         if not is_htmx(request):
             return RedirectResponse(await _dest(entity_id, db), status_code=303)
+        # remove_empty → the read row carries an OOB delete for the panel's
+        # "No citations yet." row so the first citation doesn't render above it.
         return templates.TemplateResponse(
             request,
             _READ_ROW,
-            _ctx(entity_id, c=row),
+            _ctx(entity_id, c=row, remove_empty=True),
             headers=flash_trigger(
                 "success", f"Citation <strong>{escape(f_url or f_title)}</strong> added."
             ),

--- a/src/static/admin/citations.js
+++ b/src/static/admin/citations.js
@@ -1,0 +1,33 @@
+/* citations.js — one-at-a-time toggle for the inline citations sub-row (#319).
+ *
+ * A name/event row's "Cite" button opens that entity's citations panel as a
+ * full-width sub-row (hx-get + hx-swap="afterend"). This makes it a toggle and
+ * enforces one-open-at-a-time: before every such request, close any open
+ * citations sub-row; if the button's OWN sub-row was the one open, cancel the
+ * request (preventDefault on the cancelable htmx:beforeRequest) so a second
+ * click closes it instead of re-fetching.
+ *
+ * Opt in per button with:
+ *
+ *     data-citations-toggle="<own-subrow-id>"   e.g. "citations-subrow-<entityId>"
+ *
+ * A delegated document-level listener (registered once, up front) rather than a
+ * per-button inline handler — the add-row-guard.js model: hx-boost strips the
+ * <head> from boosted navigation responses, so binding at load would miss
+ * detail pages reached by clicking a link. dispatchEvent runs listeners
+ * synchronously, so a preventDefault here lands before htmx evaluates the
+ * event's result and the request is cancelled. Reference: add-row-guard.js.
+ */
+(function () {
+  document.addEventListener('htmx:beforeRequest', function (evt) {
+    var btn =
+      evt.target && evt.target.closest ? evt.target.closest('[data-citations-toggle]') : null;
+    if (!btn) return;
+    var ownId = btn.getAttribute('data-citations-toggle');
+    var wasOpen = ownId && document.getElementById(ownId);
+    document.querySelectorAll('tr.citations-subrow').forEach(function (el) {
+      el.remove();
+    });
+    if (wasOpen) evt.preventDefault(); // toggle closed → don't re-fetch
+  });
+})();

--- a/src/templates/admin/base.html
+++ b/src/templates/admin/base.html
@@ -41,6 +41,7 @@
      data-new-row-id while its unsaved new-row is on the page. Replaces the
      per-feature event-add-guard.js / person-detail-add-name-guard.js. #}
   <script src="/static/admin/add-row-guard.js?v={{ asset_version }}" defer></script>
+  <script src="/static/admin/citations.js?v={{ asset_version }}" defer></script>
   {# Person detail name-editor scripts — same site-wide rationale (#237). All
      are document-delegated or boost-safe; defensive on pages without a person
      name editor. #}

--- a/src/templates/admin/citations/partials/_citation_form_row.html
+++ b/src/templates/admin/citations/partials/_citation_form_row.html
@@ -1,7 +1,7 @@
 {# admin/citations/partials/_citation_form_row.html — shared create/edit form (#319) #}
 {% set f = form if form is defined else None %}
 <tr id="{% if c %}citation-row-{{ c.id }}{% else %}citation-row-new-{{ entity_id }}{% endif %}">
-  <td colspan="4" style="padding:var(--space-2) var(--space-4)">
+  <td colspan="{{ 3 if locked_field else 4 }}" style="padding:var(--space-2) var(--space-4)">
     <form {% if c %}
           hx-post="/admin{{ cit_base }}/{{ c.id }}/edit-row/"
           hx-target="#citation-row-{{ c.id }}"

--- a/src/templates/admin/citations/partials/_citation_row.html
+++ b/src/templates/admin/citations/partials/_citation_row.html
@@ -7,7 +7,7 @@
     {{ c.title }}
     {% endif %}
   </td>
-  <td>{{ c.field_name or '(whole record)' }}</td>
+  {% if not locked_field %}<td>{{ c.field_name or '(whole record)' }}</td>{% endif %}
   <td>{{ c.excerpt or '—' }}</td>
   <td style="text-align:right;white-space:nowrap">
     <button type="button" class="btn btn--sm btn--secondary"
@@ -23,3 +23,7 @@
             hx-confirm="Delete this citation?">Delete</button>
   </td>
 </tr>
+{% if remove_empty %}
+{# OOB-remove the panel's "No citations yet." row after the first citation lands. #}
+<tr id="citations-empty-{{ entity_id }}" hx-swap-oob="delete"></tr>
+{% endif %}

--- a/src/templates/admin/citations/partials/_citations_panel.html
+++ b/src/templates/admin/citations/partials/_citations_panel.html
@@ -37,7 +37,7 @@
       <thead>
         <tr>
           <th scope="col">Source</th>
-          <th scope="col" style="width:8rem">Field</th>
+          {% if not locked_field %}<th scope="col" style="width:8rem">Field</th>{% endif %}
           <th scope="col">Excerpt</th>
           <th scope="col" style="width:9rem"></th>
         </tr>
@@ -48,7 +48,7 @@
         {% endfor %}
         {% if not citations %}
         <tr id="citations-empty-{{ entity_id }}">
-          <td colspan="4" style="color:var(--color-text-muted)">No citations yet.</td>
+          <td colspan="{{ 3 if locked_field else 4 }}" style="color:var(--color-text-muted)">No citations yet.</td>
         </tr>
         {% endif %}
       </tbody>

--- a/src/templates/admin/people/partials/_name_row.html
+++ b/src/templates/admin/people/partials/_name_row.html
@@ -40,14 +40,14 @@
   <td style="text-align:right">{{ n.name_type }}</td>
   <td style="text-align:right">{% if n.is_canonical %}<span class="badge badge--active">Yes</span>{% else %}—{% endif %}</td>
   <td style="text-align:right;white-space:nowrap">
-    {# Panel expands as a sub-row directly beneath this name row (tethered, #319).
-       Wipe any open citations sub-row first so only one is open at a time. #}
+    {# Toggle: close any open citations sub-row (one at a time); if this row's own
+       sub-row was the open one, cancel the fetch so Cite closes it (#319). #}
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Citations for name {{ n.name }}"
             hx-get="/admin/person-names/{{ n.id }}/citations/"
             hx-target="#name-row-{{ n.id }}"
             hx-swap="afterend"
-            hx-on:htmx:before-request="document.querySelectorAll('tr.citations-subrow').forEach(function(e){e.remove()})">Cite</button>
+            hx-on:htmx:before-request="var o=document.getElementById('citations-subrow-{{ n.id }}');document.querySelectorAll('tr.citations-subrow').forEach(function(e){e.remove()});if(o)event.preventDefault()">Cite</button>
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Edit name {{ n.name }}"
             hx-get="/admin/people/{{ person_id }}/names/{{ n.id }}/edit-row/"

--- a/src/templates/admin/people/partials/_name_row.html
+++ b/src/templates/admin/people/partials/_name_row.html
@@ -40,14 +40,14 @@
   <td style="text-align:right">{{ n.name_type }}</td>
   <td style="text-align:right">{% if n.is_canonical %}<span class="badge badge--active">Yes</span>{% else %}—{% endif %}</td>
   <td style="text-align:right;white-space:nowrap">
-    {# Toggle: close any open citations sub-row (one at a time); if this row's own
-       sub-row was the open one, cancel the fetch so Cite closes it (#319). #}
+    {# Toggle handled by citations.js (data-citations-toggle): one open at a time,
+       and re-clicking this row's own open sub-row closes it (#319). #}
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Citations for name {{ n.name }}"
             hx-get="/admin/person-names/{{ n.id }}/citations/"
             hx-target="#name-row-{{ n.id }}"
             hx-swap="afterend"
-            hx-on:htmx:before-request="var o=document.getElementById('citations-subrow-{{ n.id }}');document.querySelectorAll('tr.citations-subrow').forEach(function(e){e.remove()});if(o)event.preventDefault()">Cite</button>
+            data-citations-toggle="citations-subrow-{{ n.id }}">Cite</button>
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Edit name {{ n.name }}"
             hx-get="/admin/people/{{ person_id }}/names/{{ n.id }}/edit-row/"

--- a/src/templates/admin/shared/_event_row.html
+++ b/src/templates/admin/shared/_event_row.html
@@ -48,14 +48,14 @@
     {% endif %}
   </td>
   <td style="text-align:right;white-space:nowrap">
-    {# Toggle: close any open citations sub-row (one at a time); if this row's own
-       sub-row was the open one, cancel the fetch so Cite closes it (#319). #}
+    {# Toggle handled by citations.js (data-citations-toggle): one open at a time,
+       and re-clicking this row's own open sub-row closes it (#319). #}
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Citations for {{ ev.event_type_name }} event"
             hx-get="/admin/entity-events/{{ ev.id }}/citations/"
             hx-target="#{{ _ev_row_prefix }}-{{ ev.id }}"
             hx-swap="afterend"
-            hx-on:htmx:before-request="var o=document.getElementById('citations-subrow-{{ ev.id }}');document.querySelectorAll('tr.citations-subrow').forEach(function(e){e.remove()});if(o)event.preventDefault()">Cite</button>
+            data-citations-toggle="citations-subrow-{{ ev.id }}">Cite</button>
     {% if not ev.archived_at %}
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Edit {{ ev.event_type_name }} event"

--- a/src/templates/admin/shared/_event_row.html
+++ b/src/templates/admin/shared/_event_row.html
@@ -48,14 +48,14 @@
     {% endif %}
   </td>
   <td style="text-align:right;white-space:nowrap">
-    {# Panel expands as a sub-row directly beneath this event row (tethered, #319).
-       Wipe any open citations sub-row first so only one is open at a time. #}
+    {# Toggle: close any open citations sub-row (one at a time); if this row's own
+       sub-row was the open one, cancel the fetch so Cite closes it (#319). #}
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Citations for {{ ev.event_type_name }} event"
             hx-get="/admin/entity-events/{{ ev.id }}/citations/"
             hx-target="#{{ _ev_row_prefix }}-{{ ev.id }}"
             hx-swap="afterend"
-            hx-on:htmx:before-request="document.querySelectorAll('tr.citations-subrow').forEach(function(e){e.remove()})">Cite</button>
+            hx-on:htmx:before-request="var o=document.getElementById('citations-subrow-{{ ev.id }}');document.querySelectorAll('tr.citations-subrow').forEach(function(e){e.remove()});if(o)event.preventDefault()">Cite</button>
     {% if not ev.archived_at %}
     <button type="button" class="btn btn--sm btn--secondary"
             aria-label="Edit {{ ev.event_type_name }} event"

--- a/tests/api/admin/test_citations.py
+++ b/tests/api/admin/test_citations.py
@@ -388,6 +388,79 @@ async def test_entity_event_new_row_keeps_field_selector(client, db):
     assert '<select name="field_name"' in r.text
 
 
+# ── CR round 2 fixes (#319) ──────────────────────────────────────────────────
+
+
+async def test_first_citation_removes_empty_state(client, db, person):
+    # person starts with zero citations → panel shows the "No citations yet." row.
+    # Creating the first one must OOB-remove that row so it doesn't linger below.
+    r = await client.post(
+        _base(person) + "/",
+        headers=HTMX,
+        data={"field_name": "notes", "url": "https://s/first"},
+    )
+    assert r.status_code == 200, r.text
+    assert f'id="citations-empty-{person}"' in r.text
+    assert 'hx-swap-oob="delete"' in r.text
+
+
+def test_inline_panel_requires_subrow_colspan():
+    # An inline_panel router with a default (1) colspan re-introduces the
+    # table-layout:fixed scrunch — fail loudly at build time instead.
+    from src.api.admin._citations_shared import make_citations_router
+
+    with pytest.raises(ValueError):
+        make_citations_router(
+            entity_type="person_name",
+            prefix="/x/{entity_id}/citations",
+            tags=["t"],
+            entity_table="person_names",
+            entity_not_found_msg="nf",
+            detail_url=lambda e: "/",
+            inline_panel=True,  # no subrow_colspan → invalid
+        )
+
+
+async def test_cite_button_toggles_own_subrow(client, db):
+    nid = await _seed_name(db)
+    pid = await db.fetchval("SELECT person_id FROM person_names WHERE id=$1", nid)
+    r = await client.get(f"/admin/people/{pid}/", headers=AUTH)
+    assert r.status_code == 200
+    # Toggle: the handler cancels the fetch when this row's own sub-row is already
+    # open (references its own subrow id + preventDefault), else fetches.
+    assert f"citations-subrow-{nid}" in r.text
+    assert "preventDefault" in r.text
+
+
+async def test_locked_field_panel_drops_field_column(client, db):
+    nid = await _seed_name(db)
+    await db.execute(
+        "INSERT INTO citations (id, entity_type, entity_id, field_name, url, title)"
+        " VALUES ($1,'person_name',$2,'name','https://s/n','N')",
+        generate_id(),
+        nid,
+    )
+    p = await client.get(f"/admin/person-names/{nid}/citations/", headers=AUTH)
+    assert p.status_code == 200
+    # Locked-field panel drops the redundant Field column (header + cells).
+    assert ">Field</th>" not in p.text
+
+
+async def test_locked_field_new_row_spans_three_inner_columns(client, db):
+    nid = await _seed_name(db)
+    r = await client.get(f"/admin/person-names/{nid}/citations/new-row/", headers=AUTH)
+    assert r.status_code == 200
+    # Inner citations table is Source/Excerpt/actions = 3 when the Field col is dropped.
+    assert 'colspan="3"' in r.text
+
+
+async def test_event_panel_keeps_field_column(client, db):
+    eid = await _seed_event(db)
+    p = await client.get(f"/admin/entity-events/{eid}/citations/", headers=AUTH)
+    assert p.status_code == 200
+    assert ">Field</th>" in p.text
+
+
 # ── sub-entity delete drops its citations (no orphan) ─────────────────────────
 
 

--- a/tests/api/admin/test_citations.py
+++ b/tests/api/admin/test_citations.py
@@ -426,10 +426,9 @@ async def test_cite_button_toggles_own_subrow(client, db):
     pid = await db.fetchval("SELECT person_id FROM person_names WHERE id=$1", nid)
     r = await client.get(f"/admin/people/{pid}/", headers=AUTH)
     assert r.status_code == 200
-    # Toggle: the handler cancels the fetch when this row's own sub-row is already
-    # open (references its own subrow id + preventDefault), else fetches.
-    assert f"citations-subrow-{nid}" in r.text
-    assert "preventDefault" in r.text
+    # Toggle is wired by citations.js via data-citations-toggle naming this row's
+    # own sub-row id; the JS closes others and cancels the re-fetch when reopened.
+    assert f'data-citations-toggle="citations-subrow-{nid}"' in r.text
 
 
 async def test_locked_field_panel_drops_field_column(client, db):

--- a/tests/js/citations-toggle.test.js
+++ b/tests/js/citations-toggle.test.js
@@ -78,6 +78,24 @@ describe('citations toggle', () => {
     expect(evt.defaultPrevented).toBe(true);
   });
 
+  it('reopening one row with several open removes them all and cancels', () => {
+    // Intersection of the two behaviors: multiple sub-rows open, reopen one →
+    // every sub-row is closed AND the re-fetch is cancelled.
+    document.body.innerHTML = `
+      <table><tbody>
+        <tr id="name-row-A"></tr>
+        <tr class="citations-subrow" id="citations-subrow-A"><td></td></tr>
+        <tr id="name-row-B"></tr>
+        <tr class="citations-subrow" id="citations-subrow-B"><td></td></tr>
+      </tbody></table>
+      <button id="cite-A" data-citations-toggle="citations-subrow-A" type="button">Cite</button>
+    `;
+    mount();
+    const evt = fireBeforeRequest(document.getElementById('cite-A'));
+    expect(document.querySelectorAll('tr.citations-subrow').length).toBe(0);
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
   it('ignores requests from non-citations elements', () => {
     document.body.innerHTML = `
       <table><tbody>

--- a/tests/js/citations-toggle.test.js
+++ b/tests/js/citations-toggle.test.js
@@ -1,0 +1,94 @@
+/**
+ * Tests for src/static/admin/citations.js
+ *
+ * A name/event row's "Cite" button (data-citations-toggle="<own-subrow-id>")
+ * opens the citations panel as a sub-row. The delegated htmx:beforeRequest
+ * listener enforces one-open-at-a-time and makes Cite a toggle:
+ *   - opening: close any other open sub-row, let the request proceed;
+ *   - reopening the same row: close it and cancel the request (preventDefault).
+ * A non-citations request is ignored.
+ *
+ * Pattern: build DOM fixture → eval the script → dispatch htmx:beforeRequest →
+ * assert sub-row removal + defaultPrevented. Listener-cleanup per STYLE.md §33.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const scriptCode = readFileSync(resolve(__dirname, '../../src/static/admin/citations.js'), 'utf-8');
+
+function mount() {
+  eval(scriptCode);
+}
+
+function fireBeforeRequest(el) {
+  const evt = new Event('htmx:beforeRequest', {
+    bubbles: true,
+    cancelable: true,
+  });
+  el.dispatchEvent(evt);
+  return evt;
+}
+
+let addSpy;
+
+beforeEach(() => {
+  addSpy = vi.spyOn(document, 'addEventListener');
+});
+
+afterEach(() => {
+  for (const [type, fn] of addSpy.mock.calls) {
+    document.removeEventListener(type, fn);
+  }
+  addSpy.mockRestore();
+  document.body.innerHTML = '';
+});
+
+describe('citations toggle', () => {
+  it('opening a row closes other open sub-rows and lets the request proceed', () => {
+    document.body.innerHTML = `
+      <table><tbody>
+        <tr id="name-row-A"></tr>
+        <tr class="citations-subrow" id="citations-subrow-A"><td></td></tr>
+        <tr id="name-row-B"></tr>
+      </tbody></table>
+      <button id="cite-B" data-citations-toggle="citations-subrow-B" type="button">Cite</button>
+    `;
+    mount();
+    const evt = fireBeforeRequest(document.getElementById('cite-B'));
+    // The other row's sub-row is closed…
+    expect(document.getElementById('citations-subrow-A')).toBeNull();
+    // …and the request is NOT cancelled (B will open via htmx).
+    expect(evt.defaultPrevented).toBe(false);
+  });
+
+  it('reopening the same row closes it and cancels the request', () => {
+    document.body.innerHTML = `
+      <table><tbody>
+        <tr id="name-row-A"></tr>
+        <tr class="citations-subrow" id="citations-subrow-A"><td></td></tr>
+      </tbody></table>
+      <button id="cite-A" data-citations-toggle="citations-subrow-A" type="button">Cite</button>
+    `;
+    mount();
+    const evt = fireBeforeRequest(document.getElementById('cite-A'));
+    expect(document.getElementById('citations-subrow-A')).toBeNull();
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  it('ignores requests from non-citations elements', () => {
+    document.body.innerHTML = `
+      <table><tbody>
+        <tr class="citations-subrow" id="citations-subrow-A"><td></td></tr>
+      </tbody></table>
+      <button id="edit" type="button">Edit</button>
+    `;
+    mount();
+    const evt = fireBeforeRequest(document.getElementById('edit'));
+    // An unrelated htmx request must not disturb an open sub-row or cancel.
+    expect(document.getElementById('citations-subrow-A')).not.toBeNull();
+    expect(evt.defaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Applies the code-review directives on the #319 citations UI polish series (post-#340). Four rounds of review, all findings resolved or consciously stet.

## Changes
- **Empty-state fix (round-1 #1):** the first citation added via any panel OOB-removes the "No citations yet." row (`remove_empty` → `hx-swap-oob="delete"`) so it no longer lingers below the new row.
- **Build-time guard (round-1 #2):** `make_citations_router` raises if `inline_panel=True` and `subrow_colspan<2` — a missing colspan can no longer silently re-introduce the table-layout:fixed scrunch.
- **Toggle (round-1 #3 → round-2 refactor):** Cite is a true toggle (reopening closes it, one open at a time), extracted from duplicated inline `hx-on` handlers into a delegated `citations.js` (add-row-guard.js model), opted in via `data-citations-toggle`.
- **Locked-field column (round-1 #4):** `person_name` panels drop the redundant Field column (header + cell) and span 3 inner columns.

## Tests
- `tests/js/citations-toggle.test.js` — 4 cases (open closes others + proceeds; reopen closes self + cancels; multi-open reopen removes all + cancels; non-citations ignored).
- `tests/api/admin/test_citations.py` — empty-state OOB, colspan guard (build-time `ValueError`), locked-field column drop + 3-col inner span, toggle wiring, event panel keeps Field column.
- Full pre-ship green: Python suite + 300 JS tests, ruff/eslint/prettier clean.

## Verification notes
Both browser-JS mechanisms (toggle `preventDefault` on `htmx:beforeRequest`, `hx-swap-oob="delete"`) confirmed against the vendored htmx 2.0.8 source. One residual manual check on deploy: add a citation to a citation-less entity and confirm "No citations yet." vanishes without reload.

Commits: `420bb76`, `cbc71e8`, `778aec1`. Follow-up to #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)