### PR TITLE
#349 fix: non-HTMX 303 fallbacks on 12 admin delete handlers + CI sweep guard

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1990,6 +1990,8 @@ Deliberate exception: the public API `/search` endpoints (orgs, people) filter a
 
 Always include a `RedirectResponse` fallback on mutation routes for graceful degradation without JS.
 
+**Non-HTMX fallback is CI-enforced (#349).** Every admin mutation route (POST/PUT/DELETE/PATCH) must carry the branch — delete handlers included, even when the HTMX response is just an empty body or OOB fragment: non-HTMX → `RedirectResponse(<owning detail/list url>, status_code=303)` after the mutation. The archive-style variant (`Response(204, HX-Location)` for HTMX + `RedirectResponse` fallback) also satisfies it. `tests/api/admin/test_mutation_fallback_sweep.py` AST-sweeps `src/api/admin/*.py` and fails on any mutation handler whose body lacks `is_htmx` / `RedirectResponse` / `HX-Location`; vetted exceptions go in its `ALLOWED` set with a reason. #349 retrofitted 12 delete-family handlers (the four ancillary factories + addresses, relationships, affiliations, org children, API keys). Shared-factory redirects use the factory's `detail_url` param — citations via its `_dest` helper, which prefers `redirect_resolver` for indirect citable types (`person_name` → owning person).
+
 ### hx-boost re-execution
 
 `hx-boost="true"` on `admin-layout` makes navigation a boosted swap: htmx fetches the full page, then **discards the response `<head>` entirely** (its fragment parser strips `<head>…</head>`) and swaps only the `<body>` plus `<title>`. Two consequences:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.16.2"
+version = "0.16.3"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/api/admin/_citations_shared.py
+++ b/src/api/admin/_citations_shared.py
@@ -376,6 +376,8 @@ def make_citations_router(
         if not existing:
             raise HTTPException(status_code=404)
         await db.execute("DELETE FROM citations WHERE id=$1", citation_id)
+        if not is_htmx(request):
+            return RedirectResponse(await _dest(entity_id, db), status_code=303)
         # Body is only the OOB count fragment: the deleted row's outerHTML swap
         # resolves to nothing, while the parent row's Cite button refreshes.
         return templates.TemplateResponse(

--- a/src/api/admin/_contacts_shared.py
+++ b/src/api/admin/_contacts_shared.py
@@ -262,6 +262,8 @@ def make_contacts_router(
         if not existing:
             raise HTTPException(status_code=404)
         await db.execute("DELETE FROM contact_methods WHERE id=$1", contact_id)
+        if not is_htmx(request):
+            return RedirectResponse(detail_url(entity_id), status_code=303)
         return HTMLResponse(
             content="",
             status_code=200,

--- a/src/api/admin/_identifiers_shared.py
+++ b/src/api/admin/_identifiers_shared.py
@@ -209,6 +209,8 @@ def make_identifiers_router(
         if not existing:
             raise HTTPException(status_code=404)
         await db.execute("DELETE FROM identifiers WHERE id=$1", ident_id)
+        if not is_htmx(request):
+            return RedirectResponse(detail_url(entity_id), status_code=303)
         return HTMLResponse(
             content="",
             status_code=200,

--- a/src/api/admin/_links_shared.py
+++ b/src/api/admin/_links_shared.py
@@ -235,6 +235,8 @@ def make_links_router(
         if not existing:
             raise HTTPException(status_code=404)
         await db.execute("DELETE FROM links WHERE id=$1", link_id)
+        if not is_htmx(request):
+            return RedirectResponse(detail_url(entity_id), status_code=303)
         return HTMLResponse(
             content="", status_code=200, headers=flash_trigger("info", "Link removed.")
         )

--- a/src/api/admin/jurisdictions_addresses.py
+++ b/src/api/admin/jurisdictions_addresses.py
@@ -627,6 +627,8 @@ async def address_delete(
     async with db.transaction():
         await db.execute("DELETE FROM entity_addresses WHERE id=$1", addr_id)
         await db.execute("DELETE FROM addresses WHERE id=$1", address_id)
+    if not is_htmx(request):
+        return RedirectResponse(f"/admin/jurisdictions/{jurisdiction_id}/", status_code=303)
     return HTMLResponse(
         content="",
         status_code=200,

--- a/src/api/admin/jurisdictions_affiliations.py
+++ b/src/api/admin/jurisdictions_affiliations.py
@@ -177,6 +177,8 @@ async def jur_affiliation_delete(
     if not existing:
         raise HTTPException(status_code=404, detail="Affiliation not found")
     await db.execute("DELETE FROM organization_jurisdiction_affiliations WHERE id=$1", aff_id)
+    if not is_htmx(request):
+        return RedirectResponse(f"/admin/jurisdictions/{jurisdiction_id}/", status_code=303)
     return HTMLResponse(
         content="", status_code=200, headers=flash_trigger("info", "Affiliation removed.")
     )
@@ -292,6 +294,8 @@ async def org_affiliation_delete(
     if not existing:
         raise HTTPException(status_code=404, detail="Affiliation not found")
     await db.execute("DELETE FROM organization_jurisdiction_affiliations WHERE id=$1", aff_id)
+    if not is_htmx(request):
+        return RedirectResponse(f"/admin/orgs/{org_id}/", status_code=303)
     return HTMLResponse(
         content="", status_code=200, headers=flash_trigger("info", "Affiliation removed.")
     )

--- a/src/api/admin/jurisdictions_relationships.py
+++ b/src/api/admin/jurisdictions_relationships.py
@@ -281,6 +281,8 @@ async def relationship_delete(
     """Hard-delete a relationship edge (mistake correction)."""
     await _get_edge_or_404(rel_id, jurisdiction_id, db)
     await db.execute("DELETE FROM jurisdiction_relationships WHERE id=$1", rel_id)
+    if not is_htmx(request):
+        return RedirectResponse(f"/admin/jurisdictions/{jurisdiction_id}/", status_code=303)
     return HTMLResponse(
         content="", status_code=200, headers=flash_trigger("info", "Relationship removed.")
     )

--- a/src/api/admin/orgs.py
+++ b/src/api/admin/orgs.py
@@ -618,6 +618,8 @@ async def children_remove(
     if not child:
         raise HTTPException(status_code=404)
     await db.execute("UPDATE organizations SET parent_id=NULL WHERE id=$1", child_id)
+    if not is_htmx(request):
+        return RedirectResponse(f"/admin/orgs/{org_id}/", status_code=303)
     return HTMLResponse(
         content="",
         status_code=200,

--- a/src/api/admin/orgs_addresses.py
+++ b/src/api/admin/orgs_addresses.py
@@ -623,6 +623,8 @@ async def address_delete(
     async with db.transaction():
         await db.execute("DELETE FROM entity_addresses WHERE id=$1", addr_id)
         await db.execute("DELETE FROM addresses WHERE id=$1", address_id)
+    if not is_htmx(request):
+        return RedirectResponse(f"/admin/orgs/{org_id}/", status_code=303)
     return HTMLResponse(
         content="",
         status_code=200,

--- a/src/api/admin/people_addresses.py
+++ b/src/api/admin/people_addresses.py
@@ -614,6 +614,8 @@ async def address_delete(
     async with db.transaction():
         await db.execute("DELETE FROM entity_addresses WHERE id=$1", addr_id)
         await db.execute("DELETE FROM addresses WHERE id=$1", address_id)
+    if not is_htmx(request):
+        return RedirectResponse(f"/admin/people/{person_id}/", status_code=303)
     return HTMLResponse(
         content="",
         status_code=200,

--- a/src/api/admin/settings_api_keys.py
+++ b/src/api/admin/settings_api_keys.py
@@ -290,6 +290,8 @@ async def api_key_delete(
     if not existing:
         raise HTTPException(status_code=404)
     await db.execute("DELETE FROM api_keys WHERE id=$1", key_id)
+    if not is_htmx(request):
+        return RedirectResponse("/admin/settings/api-keys/", status_code=303)
     return HTMLResponse(
         content="",
         status_code=200,

--- a/tests/api/admin/test_mutation_fallback_sweep.py
+++ b/tests/api/admin/test_mutation_fallback_sweep.py
@@ -1,0 +1,77 @@
+"""Source-level sweep: every admin mutation route carries a non-HTMX fallback (#349).
+
+§32 convention: mutation handlers branch on ``is_htmx(request)`` and return a
+``RedirectResponse`` (or ``HX-Location`` 204) fallback for non-HTMX clients.
+This guard parses every ``src/api/admin/*.py`` module and flags any
+POST/PUT/DELETE/PATCH-decorated handler whose body carries none of the fallback
+markers, so a new mutation route without the branch fails CI instead of
+accumulating (the drift that produced the 12 handlers fixed in #349).
+
+The check is heuristic (marker strings anywhere in the handler body), which is
+the right cost/benefit for a ratchet: it counts factory-made handlers once at
+the source level and cannot false-negative on a handler that genuinely lacks
+the branch. Vetted exceptions go in ALLOWED with a reason comment.
+"""
+
+import ast
+from pathlib import Path
+
+ADMIN_DIR = Path(__file__).resolve().parents[3] / "src" / "api" / "admin"
+
+_MUTATION_METHODS = {"post", "put", "delete", "patch"}
+
+# A handler satisfies the convention when its body mentions any of these:
+# - is_htmx / RedirectResponse: the standard §32 branch
+# - HX-Location: the archive-style variant (204 + HX-Location for HTMX,
+#   RedirectResponse otherwise) where the redirect happens client-side
+_FALLBACK_MARKERS = ("is_htmx", "RedirectResponse", "HX-Location")
+
+# "<file>.py::<handler>" entries exempt from the sweep. Each needs a reason.
+ALLOWED: frozenset[str] = frozenset()
+
+
+def _mutation_handlers_without_fallback() -> list[str]:
+    offenders = []
+    for path in sorted(ADMIN_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+                continue
+            is_mutation = any(
+                isinstance(dec, ast.Call)
+                and isinstance(dec.func, ast.Attribute)
+                and dec.func.attr in _MUTATION_METHODS
+                for dec in node.decorator_list
+            )
+            if not is_mutation:
+                continue
+            body_src = ast.unparse(node)
+            if any(marker in body_src for marker in _FALLBACK_MARKERS):
+                continue
+            offenders.append(f"{path.name}::{node.name}")
+    return [o for o in offenders if o not in ALLOWED]
+
+
+def test_every_admin_mutation_route_has_nonhtmx_fallback():
+    offenders = _mutation_handlers_without_fallback()
+    assert offenders == [], (
+        "Admin mutation routes missing the §32 non-HTMX fallback branch"
+        " (is_htmx → RedirectResponse, or 204 + HX-Location):"
+        f" {offenders}. Add the branch, or allowlist with a reason."
+    )
+
+
+def test_sweep_sees_admin_mutation_routes():
+    """Self-check: the sweep's decorator matching actually finds routes."""
+    count = 0
+    for path in sorted(ADMIN_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef) and any(
+                isinstance(dec, ast.Call)
+                and isinstance(dec.func, ast.Attribute)
+                and dec.func.attr in _MUTATION_METHODS
+                for dec in node.decorator_list
+            ):
+                count += 1
+    assert count > 50, f"sweep found only {count} mutation routes — matcher broken?"

--- a/tests/api/admin/test_mutation_fallback_sweep.py
+++ b/tests/api/admin/test_mutation_fallback_sweep.py
@@ -45,7 +45,9 @@ def _mutation_handlers_without_fallback() -> list[str]:
             )
             if not is_mutation:
                 continue
-            body_src = ast.unparse(node)
+            # Scan only the handler body — a marker in a decorator argument
+            # must not satisfy the guard (CR #350 finding 2).
+            body_src = "\n".join(ast.unparse(stmt) for stmt in node.body)
             if any(marker in body_src for marker in _FALLBACK_MARKERS):
                 continue
             offenders.append(f"{path.name}::{node.name}")

--- a/tests/api/admin/test_nonhtmx_delete_fallbacks.py
+++ b/tests/api/admin/test_nonhtmx_delete_fallbacks.py
@@ -1,0 +1,321 @@
+"""Integration tests: delete handlers 303-redirect non-HTMX clients (#349).
+
+Each of the 12 delete-family handlers flagged in #349 returned an HTMX-shaped
+body (empty string, OOB fragment) to any caller. These tests drive each route
+without the HX-Request header and assert the §32 fallback: the mutation still
+happens, then a 303 redirect to the owning detail/list page. Factory-made
+handlers (contacts/links/identifiers/citations) are covered through one
+representative mount each; citations twice to pin both ``_dest`` paths
+(plain ``detail_url`` and the ``redirect_resolver`` indirection).
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from src.api.admin.deps import get_db
+from src.api.main import app
+from src.core.db import generate_id
+
+pytestmark = [pytest.mark.integration]
+
+AUTH_HEADERS = {"X-ExeDev-UserID": "usr_test", "X-ExeDev-Email": "admin@test.com"}
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def db(db_pool):
+    """Pool-acquired connection wrapped in a rolled-back transaction."""
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            yield conn
+        finally:
+            await tr.rollback()
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def client(db):
+    """Non-following AsyncClient so 303 responses are observable."""
+
+    async def _get_db_override():
+        yield db
+
+    app.dependency_overrides[get_db] = _get_db_override
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test", follow_redirects=False
+    ) as c:
+        yield c
+    app.dependency_overrides.pop(get_db, None)
+
+
+async def _seed_org(db) -> str:
+    oid = generate_id()
+    await db.execute("INSERT INTO organizations (id) VALUES ($1)", oid)
+    return oid
+
+
+async def _seed_person(db) -> str:
+    pid = generate_id()
+    await db.execute("INSERT INTO people (id) VALUES ($1)", pid)
+    return pid
+
+
+async def _seed_jurisdiction(db, slug_marker: str) -> str:
+    jid = generate_id()
+    type_id = await db.fetchval("SELECT id FROM jurisdiction_types WHERE slug='county'")
+    await db.execute(
+        "INSERT INTO jurisdictions (id, slug, name, type_id) VALUES ($1,$2,$3,$4)",
+        jid,
+        f"test-349-{slug_marker}-{jid[-6:].lower()}",
+        f"Test 349 {slug_marker}",
+        type_id,
+    )
+    return jid
+
+
+async def _seed_entity_address(db, entity_type: str, entity_id: str) -> str:
+    address_id, ea_id = generate_id(), generate_id()
+    await db.execute(
+        "INSERT INTO addresses (id, standardized, country) VALUES ($1,'1 Test St','US')",
+        address_id,
+    )
+    await db.execute(
+        "INSERT INTO entity_addresses (id, entity_type, entity_id, address_id, address_type)"
+        " VALUES ($1,$2,$3,$4,'physical')",
+        ea_id,
+        entity_type,
+        entity_id,
+        address_id,
+    )
+    return ea_id
+
+
+def _assert_303(r, expected_location: str):
+    assert r.status_code == 303, f"expected 303, got {r.status_code}: {r.text[:200]}"
+    assert r.headers["location"] == expected_location
+
+
+# --- shared factories (one representative mount each) ---
+
+
+async def test_contact_delete_nonhtmx_redirects(client, db):
+    oid, cid = await _seed_org(db), generate_id()
+    await db.execute(
+        "INSERT INTO contact_methods (id, entity_type, entity_id, contact_type, value)"
+        " VALUES ($1,'organization',$2,'phone','+13605551234')",
+        cid,
+        oid,
+    )
+    r = await client.delete(f"/admin/orgs/{oid}/contacts/{cid}/", headers=AUTH_HEADERS)
+    _assert_303(r, f"/admin/orgs/{oid}/")
+    assert await db.fetchval("SELECT count(*) FROM contact_methods WHERE id=$1", cid) == 0
+
+
+async def test_link_delete_nonhtmx_redirects(client, db):
+    oid, lid = await _seed_org(db), generate_id()
+    lt_id = await db.fetchval("SELECT id FROM link_types WHERE slug='website'")
+    await db.execute(
+        "INSERT INTO links (id, entity_type, entity_id, url, link_type_id)"
+        " VALUES ($1,'organization',$2,'https://example.com/',$3)",
+        lid,
+        oid,
+        lt_id,
+    )
+    r = await client.delete(f"/admin/orgs/{oid}/links/{lid}/", headers=AUTH_HEADERS)
+    _assert_303(r, f"/admin/orgs/{oid}/")
+    assert await db.fetchval("SELECT count(*) FROM links WHERE id=$1", lid) == 0
+
+
+async def test_identifier_delete_nonhtmx_redirects(client, db):
+    oid, iid = await _seed_org(db), generate_id()
+    type_id = await db.fetchval(
+        "SELECT id FROM entity_identifier_types WHERE entity_type='organization' LIMIT 1"
+    )
+    if not type_id:
+        pytest.skip("No organization identifier types seeded")
+    await db.execute(
+        "INSERT INTO identifiers (id, entity_id, entity_identifier_type_id, value)"
+        " VALUES ($1,$2,$3,'TEST-349')",
+        iid,
+        oid,
+        type_id,
+    )
+    r = await client.delete(f"/admin/orgs/{oid}/identifiers/{iid}/", headers=AUTH_HEADERS)
+    _assert_303(r, f"/admin/orgs/{oid}/")
+    assert await db.fetchval("SELECT count(*) FROM identifiers WHERE id=$1", iid) == 0
+
+
+async def test_citation_delete_nonhtmx_redirects_detail_url(client, db):
+    oid, cid = await _seed_org(db), generate_id()
+    await db.execute(
+        "INSERT INTO citations (id, entity_type, entity_id, url)"
+        " VALUES ($1,'organization',$2,'https://example.com/src')",
+        cid,
+        oid,
+    )
+    r = await client.delete(f"/admin/orgs/{oid}/citations/{cid}/", headers=AUTH_HEADERS)
+    _assert_303(r, f"/admin/orgs/{oid}/")
+    assert await db.fetchval("SELECT count(*) FROM citations WHERE id=$1", cid) == 0
+
+
+async def test_citation_delete_nonhtmx_redirects_via_resolver(client, db):
+    """person_name citations resolve the redirect to the owning person (#319)."""
+    pid, nid, cid = await _seed_person(db), generate_id(), generate_id()
+    await db.execute(
+        "INSERT INTO person_names (id, person_id, name, is_canonical)"
+        " VALUES ($1,$2,'Test ThreeFourNine',TRUE)",
+        nid,
+        pid,
+    )
+    await db.execute(
+        "INSERT INTO citations (id, entity_type, entity_id, url)"
+        " VALUES ($1,'person_name',$2,'https://example.com/src')",
+        cid,
+        nid,
+    )
+    r = await client.delete(f"/admin/person-names/{nid}/citations/{cid}/", headers=AUTH_HEADERS)
+    _assert_303(r, f"/admin/people/{pid}/")
+    assert await db.fetchval("SELECT count(*) FROM citations WHERE id=$1", cid) == 0
+
+
+# --- standalone handlers ---
+
+
+async def test_org_address_delete_nonhtmx_redirects(client, db):
+    oid = await _seed_org(db)
+    ea_id = await _seed_entity_address(db, "organization", oid)
+    r = await client.delete(f"/admin/orgs/{oid}/addresses/{ea_id}/", headers=AUTH_HEADERS)
+    _assert_303(r, f"/admin/orgs/{oid}/")
+    assert await db.fetchval("SELECT count(*) FROM entity_addresses WHERE id=$1", ea_id) == 0
+
+
+async def test_person_address_delete_nonhtmx_redirects(client, db):
+    pid = await _seed_person(db)
+    ea_id = await _seed_entity_address(db, "person", pid)
+    r = await client.delete(f"/admin/people/{pid}/addresses/{ea_id}/", headers=AUTH_HEADERS)
+    _assert_303(r, f"/admin/people/{pid}/")
+    assert await db.fetchval("SELECT count(*) FROM entity_addresses WHERE id=$1", ea_id) == 0
+
+
+async def test_jurisdiction_address_delete_nonhtmx_redirects(client, db):
+    jid = await _seed_jurisdiction(db, "addr")
+    ea_id = await _seed_entity_address(db, "jurisdiction", jid)
+    r = await client.delete(f"/admin/jurisdictions/{jid}/addresses/{ea_id}/", headers=AUTH_HEADERS)
+    _assert_303(r, f"/admin/jurisdictions/{jid}/")
+    assert await db.fetchval("SELECT count(*) FROM entity_addresses WHERE id=$1", ea_id) == 0
+
+
+async def test_relationship_delete_nonhtmx_redirects(client, db):
+    jid_a = await _seed_jurisdiction(db, "rel-a")
+    jid_b = await _seed_jurisdiction(db, "rel-b")
+    rel_id = generate_id()
+    rel_type = await db.fetchval(
+        "SELECT id FROM jurisdiction_relationship_types WHERE slug='is_fully_contained_by'"
+    )
+    await db.execute(
+        "INSERT INTO jurisdiction_relationships (id, from_id, to_id, rel_type_id)"
+        " VALUES ($1,$2,$3,$4)",
+        rel_id,
+        jid_a,
+        jid_b,
+        rel_type,
+    )
+    r = await client.delete(
+        f"/admin/jurisdictions/{jid_a}/relationships/{rel_id}/", headers=AUTH_HEADERS
+    )
+    _assert_303(r, f"/admin/jurisdictions/{jid_a}/")
+    assert (
+        await db.fetchval("SELECT count(*) FROM jurisdiction_relationships WHERE id=$1", rel_id)
+        == 0
+    )
+
+
+async def _seed_affiliation(db, oid: str, jid: str) -> str:
+    aff_id = generate_id()
+    aff_type = await db.fetchval(
+        "SELECT id FROM organization_jurisdiction_affiliation_types WHERE slug='governing'"
+    )
+    await db.execute(
+        "INSERT INTO organization_jurisdiction_affiliations"
+        " (id, organization_id, jurisdiction_id, affiliation_type_id) VALUES ($1,$2,$3,$4)",
+        aff_id,
+        oid,
+        jid,
+        aff_type,
+    )
+    return aff_id
+
+
+async def test_jur_affiliation_delete_nonhtmx_redirects(client, db):
+    oid, jid = await _seed_org(db), await _seed_jurisdiction(db, "jaff")
+    aff_id = await _seed_affiliation(db, oid, jid)
+    r = await client.delete(
+        f"/admin/jurisdictions/{jid}/affiliations/{aff_id}/", headers=AUTH_HEADERS
+    )
+    _assert_303(r, f"/admin/jurisdictions/{jid}/")
+    assert (
+        await db.fetchval(
+            "SELECT count(*) FROM organization_jurisdiction_affiliations WHERE id=$1", aff_id
+        )
+        == 0
+    )
+
+
+async def test_org_affiliation_delete_nonhtmx_redirects(client, db):
+    oid, jid = await _seed_org(db), await _seed_jurisdiction(db, "oaff")
+    aff_id = await _seed_affiliation(db, oid, jid)
+    r = await client.delete(
+        f"/admin/orgs/{oid}/jurisdiction-affiliations/{aff_id}/", headers=AUTH_HEADERS
+    )
+    _assert_303(r, f"/admin/orgs/{oid}/")
+    assert (
+        await db.fetchval(
+            "SELECT count(*) FROM organization_jurisdiction_affiliations WHERE id=$1", aff_id
+        )
+        == 0
+    )
+
+
+async def test_children_remove_nonhtmx_redirects(client, db):
+    parent = await _seed_org(db)
+    child = generate_id()
+    await db.execute("INSERT INTO organizations (id, parent_id) VALUES ($1,$2)", child, parent)
+    r = await client.delete(f"/admin/orgs/{parent}/children/{child}/", headers=AUTH_HEADERS)
+    _assert_303(r, f"/admin/orgs/{parent}/")
+    assert await db.fetchval("SELECT parent_id FROM organizations WHERE id=$1", child) is None
+
+
+async def test_api_key_delete_nonhtmx_redirects(client, db):
+    kid = generate_id()
+    await db.execute(
+        "INSERT INTO app_users (id, email) VALUES ('usr_test','admin@test.com')"
+        " ON CONFLICT (id) DO NOTHING"
+    )
+    await db.execute(
+        "INSERT INTO api_keys (id, user_id, label, key_prefix, key_hash)"
+        " VALUES ($1,'usr_test','t349','pm_t349xx',$2)",
+        kid,
+        "349afeed" * 8,
+    )
+    r = await client.delete(f"/admin/settings/api-keys/{kid}/", headers=AUTH_HEADERS)
+    _assert_303(r, "/admin/settings/api-keys/")
+    assert await db.fetchval("SELECT count(*) FROM api_keys WHERE id=$1", kid) == 0
+
+
+# --- HTMX behavior unchanged ---
+
+
+async def test_contact_delete_htmx_still_returns_empty_body(client, db):
+    oid, cid = await _seed_org(db), generate_id()
+    await db.execute(
+        "INSERT INTO contact_methods (id, entity_type, entity_id, contact_type, value)"
+        " VALUES ($1,'organization',$2,'phone','+13605551234')",
+        cid,
+        oid,
+    )
+    r = await client.delete(
+        f"/admin/orgs/{oid}/contacts/{cid}/", headers={**AUTH_HEADERS, "HX-Request": "true"}
+    )
+    assert r.status_code == 200
+    assert r.text == ""

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.16.2"
+version = "0.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Closes #349. Also closes out #341 review finding 7.

## What

Every admin mutation route must branch on `is_htmx(request)` with a `RedirectResponse` fallback (STYLE.md §32). The audit (AST sweep, verified by hand — details in the [issue comment](https://github.com/CannObserv/power-map/issues/349#issuecomment-5135211774)) found **12** delete-family handlers returning HTMX-shaped bodies to any caller — the 10 listed in the issue plus both `jurisdictions_affiliations.py` deletes the original regex missed.

## Fix

Each handler now returns `RedirectResponse(<owning detail/list url>, status_code=303)` for non-HTMX callers after the mutation; HTMX behavior unchanged.

- Factories (4): `_contacts_shared` / `_links_shared` / `_identifiers_shared` via `detail_url(entity_id)`; `_citations_shared` via `await _dest(entity_id, db)` so indirect citable types (`person_name`, `entity_event`) redirect to the owning entity. The OOB cite-count fragment is dropped on the non-HTMX path — the redirect target re-renders counts from row-fetch SQL (#341 rule).
- Standalone (8): three `address_delete`s, `relationship_delete`, both affiliation deletes → owning entity detail; `children_remove` → parent org detail; `api_key_delete` → `/admin/settings/api-keys/`.

## Guard

`tests/api/admin/test_mutation_fallback_sweep.py` AST-sweeps `src/api/admin/*.py`: any POST/PUT/DELETE/PATCH handler whose body lacks `is_htmx` / `RedirectResponse` / `HX-Location` fails CI. Empty `ALLOWED` set for vetted exceptions. Red phase reported exactly the 12 offenders.

## Tests

TDD: 14 new integration tests (`test_nonhtmx_delete_fallbacks.py`) — one per handler family, citations pinned on both `_dest` paths (plain `detail_url` + `redirect_resolver`), plus an HTMX-unchanged regression test. All were red (200-instead-of-303) before the fix; all 16 new tests green after.

Full suite: 4041 passed. 18 a11y citation-route failures are pre-existing on main (#341 note); 2 `test_health` failures were an artifact of the version bump landing mid-run — both pass on re-run.

Docs: STYLE.md §32 documents the CI-enforced convention. Version 0.16.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
