### PR TITLE
#346 fix: JSON logs carry timestamp, level, logger name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.16.5"
+version = "0.16.6"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/core/logging.py
+++ b/src/core/logging.py
@@ -9,7 +9,15 @@ from pythonjsonlogger.json import JsonFormatter
 def configure_logging(level: int = logging.INFO) -> None:
     """Configure root logger with JSON formatting. Call once at entry points."""
     handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(JsonFormatter())
+    # Keys must be named in fmt: a bare JsonFormatter() defaults to
+    # "%(message)s" and emits records with no level, logger, or timestamp.
+    handler.setFormatter(
+        JsonFormatter(
+            "%(levelname)s %(name)s %(message)s",
+            timestamp=True,
+            rename_fields={"levelname": "level", "name": "logger"},
+        )
+    )
     root = logging.getLogger()
     root.setLevel(level)
     root.handlers = [handler]

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -1,0 +1,22 @@
+"""Regression test: JSON log records carry timestamp, level, and logger name."""
+
+import json
+import logging
+
+from src.core.logging import configure_logging, get_logger
+
+
+def test_log_record_includes_structured_fields(capsys):
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    try:
+        configure_logging()
+        get_logger("src.some.module").warning("hello %s", "world")
+    finally:
+        root.handlers, root.level = saved_handlers, saved_level
+
+    record = json.loads(capsys.readouterr().out)
+    assert record["message"] == "hello world"
+    assert record["level"] == "WARNING"
+    assert record["logger"] == "src.some.module"
+    assert "timestamp" in record

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.16.5"
+version = "0.16.6"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Closes #346.

## Problem
`configure_logging()` built `JsonFormatter()` with no fmt string. python-json-logger derives JSON keys from the `%(field)s` placeholders in the fmt, which defaults to `"%(message)s"` — so every record serialized as just `{"message": "..."}`: no level, logger name, or timestamp. Can't filter WARNING+ or attribute a line to a module from the JSON alone.

Cohort-wide defect (skills#69); this ports the scaffold fix to power-map's copy.

## Fix
Name the keys in the fmt string, enable `timestamp=True`, rename `levelname`→`level` / `name`→`logger`:

```json
{"level": "WARNING", "logger": "src.some.module", "message": "hello world", "timestamp": "2026-07-31T17:12:28.893283+00:00"}
```

Field set `{timestamp, level, logger, message}` matches structlog defaults, so the pending structlog+OTel migration (skills#68) won't churn log consumers. Kept an explanatory comment above `setFormatter` so a future cleanup doesn't revert to bare `JsonFormatter()`.

## Test
`tests/core/test_logging.py` pins the field contract (verbatim from the scaffold). Verified Red (`KeyError: 'level'`) → Green.

## Verification
- Full unit suite: **1084 passed, 3 skipped, 0 failures**
- ruff lint + format: clean
- Version bumped 0.16.5 → 0.16.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)