### PR TITLE
#304 feat: role data-quality sweep — archive artifacts + normalize typos

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -442,6 +442,38 @@ uv run "${env_args[@]}" python -m scripts.split_speaker_designate            # d
 uv run "${env_args[@]}" python -m scripts.split_speaker_designate --execute  # commit
 ```
 
+## Role data-quality sweep (idempotent, #304)
+
+`scripts/sweep_role_data_quality.py` — follow-on to #266, data-only. Operates **only**
+on plain free-text roles (`role_type_id IS NULL AND jurisdiction_id IS NULL`, whose
+match key is `(org, lower(title))` = `uq_role_org_title`):
+
+- **Archive non-role artifacts** — `Guest` / `Visitor or Guest`: attendance noise that
+  leaks into membership queries. Archives active assignments, then the role (never
+  hard-deleted).
+- **Normalize typo'd titles** — `Principle` → `Principal`: a misspelling orphans the
+  `(org, lower(title))` match key. Renames in place; when the same org already carries
+  the canonical role (would collide on `uq_role_org_title`), instead **merges** the typo
+  role in — assignments re-pointed with `(person, start_date)` dedup, loser notes +
+  role-level ancillary preserved onto the survivor (#324/#326), loser hard-deleted
+  (mirrors admin `role_merge`).
+
+The `Participant` disposition, bare `Chairman` normalization, and `Ranking Democratic
+Member` typed-fold are deliberately **out of scope** — vocabulary judgment calls for
+#266, not a mechanical sweep. Idempotent: canonical titles aren't typo keys and artifact
+roles archive once, so re-runs no-op. The dry run distinguishes `would_rename` vs the
+destructive `would_merge` per row.
+
+```bash
+# Build --env-file flags (see § Environment)
+env_args=()
+[ -f /etc/power-map/.env ] && env_args+=(--env-file /etc/power-map/.env)
+[ -f .env ] && env_args+=(--env-file .env)
+
+uv run "${env_args[@]}" python -m scripts.sweep_role_data_quality            # dry run
+uv run "${env_args[@]}" python -m scripts.sweep_role_data_quality --execute  # commit
+```
+
 ## Notes → citations migration (issue #319)
 
 `scripts/migrate_notes_to_citations.py` extracts bare `http(s)` URLs from

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.16.6"
+version = "0.16.7"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/sweep_role_data_quality.py
+++ b/scripts/sweep_role_data_quality.py
@@ -1,0 +1,292 @@
+"""Data-only sweep of non-role observation artifacts + typo'd role titles (#304).
+
+Follow-on to #266. Two mechanical fixes over **plain free-text roles** — those
+with ``role_type_id IS NULL AND jurisdiction_id IS NULL``, whose match key is
+``(organization_id, lower(title))`` (``uq_role_org_title``). Typed / jurisdictional
+roles match structurally and are never touched.
+
+1. **Archive non-role artifacts** — ``Guest`` / ``Visitor or Guest``: attendance
+   noise, not offices, that leaks into "membership" queries. Their active
+   assignments are archived, then the role is archived (never hard-deleted).
+
+2. **Normalize typo'd titles** — ``Principle`` → ``Principal``: a misspelling is
+   an orphan ``(org, lower(title))`` match key, so a fresh observation of the
+   correct spelling mints a *second* role instead of matching. The fix normally
+   renames in place; when the same org **already** carries the canonical role, it
+   would collide on ``uq_role_org_title``, so the typo role is instead **merged**
+   into the canonical one — assignments re-pointed (same ``(person, start_date)``
+   deduped), role-level ancillary re-homed (#324/#326), loser hard-deleted.
+
+Scope intentionally excludes the judgment calls surfaced in #304 — ``Participant``
+disposition, bare ``Chairman`` normalization, and the ``Ranking Democratic Member``
+typed-fold — which are vocabulary decisions for #266, not a mechanical sweep.
+
+Idempotent: canonical titles are not typo keys and artifact roles archive once, so
+re-runs are no-ops. Coverage is unbounded — every matching active role is handled
+each run (e.g. after upstream backfills add more).
+
+Usage:
+    uv run python -m scripts.sweep_role_data_quality            # dry run
+    uv run python -m scripts.sweep_role_data_quality --execute  # commit
+"""
+
+import argparse
+import asyncio
+import os
+from collections import Counter
+from typing import Literal, TypedDict
+
+import asyncpg
+
+from src.core.ancillary_migrate import (
+    rehome_conflicting_assignment_ancillary,
+    rehome_role_ancillary,
+)
+from src.core.logging import configure_logging, get_logger
+
+logger = get_logger(__name__)
+
+# Non-role observation artifacts to archive (lowercased match keys, #304).
+ARCHIVE_TITLES: frozenset[str] = frozenset({"guest", "visitor or guest"})
+
+# Typo'd title (lowercased) → canonical display spelling (#304). Keys must be
+# lowercase; values must not themselves be typo keys (no rename chains).
+RENAME_MAP: dict[str, str] = {"principle": "Principal"}
+
+
+def canonical_rename(title: str) -> str | None:
+    """Return the canonical spelling for a typo'd ``title``, or None if not a typo.
+
+    Case-insensitive and whitespace-tolerant. A title already at its canonical
+    form is not a key, so returns None — keeps re-runs idempotent.
+    """
+    return RENAME_MAP.get(title.strip().lower())
+
+
+ArchiveStatus = Literal["archived", "planned"]
+RenameStatus = Literal["renamed", "merged", "planned"]
+
+
+class ArchiveAction(TypedDict):
+    """Outcome for one archived artifact role."""
+
+    role_id: str
+    organization_id: str
+    title: str
+    active_assignments: int
+    status: ArchiveStatus
+
+
+class RenameAction(TypedDict):
+    """Outcome for one normalized title: renamed in place, or merged on collision."""
+
+    role_id: str
+    organization_id: str
+    from_title: str
+    to_title: str
+    target_role_id: str | None  # set only when merged into an existing canonical role
+    status: RenameStatus
+
+
+class Report(TypedDict):
+    """Full sweep outcome."""
+
+    archived: list[ArchiveAction]
+    renamed: list[RenameAction]
+
+
+# Plain free-text roles only: (org, lower(title)) is the match key exactly when
+# both structural fields are NULL, so uq_role_org_title governs collisions here.
+_ARTIFACT_ROLES_SQL = """
+SELECT r.id, r.organization_id, r.title,
+       count(ra.id) FILTER (WHERE ra.archived_at IS NULL) AS active_assignments
+FROM roles r
+LEFT JOIN role_assignments ra ON ra.role_id = r.id
+WHERE r.archived_at IS NULL
+  AND r.role_type_id IS NULL AND r.jurisdiction_id IS NULL
+  AND lower(r.title) = ANY($1)
+GROUP BY r.id, r.organization_id, r.title
+ORDER BY r.title, r.id
+"""
+
+_TYPO_ROLES_SQL = """
+SELECT r.id, r.organization_id, r.title
+FROM roles r
+WHERE r.archived_at IS NULL
+  AND r.role_type_id IS NULL AND r.jurisdiction_id IS NULL
+  AND lower(r.title) = ANY($1)
+ORDER BY r.title, r.id
+"""
+
+# A same-org active plain role already at the canonical title (excluding self).
+_CANONICAL_PEER_SQL = """
+SELECT r.id
+FROM roles r
+WHERE r.archived_at IS NULL
+  AND r.role_type_id IS NULL AND r.jurisdiction_id IS NULL
+  AND r.organization_id = $1 AND lower(r.title) = $2 AND r.id <> $3
+ORDER BY r.id
+LIMIT 1
+"""
+
+_ARCHIVE_ASSIGNMENTS_SQL = (
+    "UPDATE role_assignments SET archived_at = NOW() WHERE role_id = $1 AND archived_at IS NULL"
+)
+_ARCHIVE_ROLE_SQL = "UPDATE roles SET archived_at = NOW() WHERE id = $1"
+_RENAME_ROLE_SQL = "UPDATE roles SET title = $2 WHERE id = $1"
+
+# Merge (mirrors src/api/admin/orgs_roles.py::role_merge): dedup conflicting
+# assignments by (person, start_date), re-home their ancillary onto the survivor
+# before the delete (#324), re-point the rest, re-home role-level ancillary (#326),
+# then hard-delete the loser role.
+_CONFLICT_PAIRS_SQL = """
+SELECT l.id AS loser_ra, w.id AS winner_ra
+FROM role_assignments l
+JOIN role_assignments w
+  ON w.role_id = $2 AND w.archived_at IS NULL
+ AND w.person_id = l.person_id
+ AND w.start_date IS NOT DISTINCT FROM l.start_date
+WHERE l.role_id = $1 AND l.archived_at IS NULL
+"""
+
+_DELETE_CONFLICT_ASSIGNMENTS_SQL = """
+DELETE FROM role_assignments ra
+WHERE ra.role_id = $1 AND ra.archived_at IS NULL
+  AND EXISTS (
+      SELECT 1 FROM role_assignments w
+      WHERE w.role_id = $2 AND w.archived_at IS NULL
+        AND w.person_id = ra.person_id
+        AND w.start_date IS NOT DISTINCT FROM ra.start_date
+  )
+"""
+
+_REPOINT_ASSIGNMENTS_SQL = "UPDATE role_assignments SET role_id = $1 WHERE role_id = $2"
+_DELETE_ROLE_SQL = "DELETE FROM roles WHERE id = $1"
+
+
+async def _archive_artifacts(conn: asyncpg.Connection, *, execute: bool) -> list[ArchiveAction]:
+    """Archive artifact roles (Guest / Visitor or Guest) and their active assignments."""
+    actions: list[ArchiveAction] = []
+    for row in await conn.fetch(_ARTIFACT_ROLES_SQL, list(ARCHIVE_TITLES)):
+        action: ArchiveAction = {
+            "role_id": row["id"],
+            "organization_id": row["organization_id"],
+            "title": row["title"],
+            "active_assignments": row["active_assignments"],
+            "status": "planned",
+        }
+        actions.append(action)
+        if not execute:
+            continue
+        await conn.execute(_ARCHIVE_ASSIGNMENTS_SQL, row["id"])
+        await conn.execute(_ARCHIVE_ROLE_SQL, row["id"])
+        action["status"] = "archived"
+        logger.info(
+            "Archived artifact role %r (%s), %d assignment(s)",
+            row["title"],
+            row["id"],
+            row["active_assignments"],
+        )
+    return actions
+
+
+async def _merge_into_canonical(conn: asyncpg.Connection, loser_id: str, winner_id: str) -> None:
+    """Fold a typo role into the same-org canonical role (mirrors admin role_merge)."""
+    conflict_pairs = await conn.fetch(_CONFLICT_PAIRS_SQL, loser_id, winner_id)
+    await rehome_conflicting_assignment_ancillary(
+        conn, [(r["loser_ra"], r["winner_ra"]) for r in conflict_pairs]
+    )
+    await conn.execute(_DELETE_CONFLICT_ASSIGNMENTS_SQL, loser_id, winner_id)
+    await conn.execute(_REPOINT_ASSIGNMENTS_SQL, winner_id, loser_id)
+    await rehome_role_ancillary(conn, loser_id, winner_id)
+    await conn.execute(_DELETE_ROLE_SQL, loser_id)
+
+
+async def _normalize_typos(conn: asyncpg.Connection, *, execute: bool) -> list[RenameAction]:
+    """Rename typo'd titles in place, or merge onto an existing same-org canonical role."""
+    actions: list[RenameAction] = []
+    for row in await conn.fetch(_TYPO_ROLES_SQL, list(RENAME_MAP)):
+        canonical = canonical_rename(row["title"])
+        if canonical is None:  # defensive; SQL already filters to RENAME_MAP keys
+            continue
+        peer = await conn.fetchval(
+            _CANONICAL_PEER_SQL, row["organization_id"], canonical.lower(), row["id"]
+        )
+        action: RenameAction = {
+            "role_id": row["id"],
+            "organization_id": row["organization_id"],
+            "from_title": row["title"],
+            "to_title": canonical,
+            "target_role_id": peer,
+            "status": "planned",
+        }
+        actions.append(action)
+        if not execute:
+            continue
+        if peer is None:
+            await conn.execute(_RENAME_ROLE_SQL, row["id"], canonical)
+            action["status"] = "renamed"
+            logger.info("Renamed role %s %r → %r", row["id"], row["title"], canonical)
+        else:
+            await _merge_into_canonical(conn, row["id"], peer)
+            action["status"] = "merged"
+            logger.info(
+                "Merged typo role %s %r into canonical %s (%r)",
+                row["id"],
+                row["title"],
+                peer,
+                canonical,
+            )
+    return actions
+
+
+async def sweep_role_data_quality(conn: asyncpg.Connection, *, execute: bool) -> Report:
+    """Archive artifact roles and normalize typo'd titles. Only mutates when execute."""
+    archived = await _archive_artifacts(conn, execute=execute)
+    renamed = await _normalize_typos(conn, execute=execute)
+    return Report(archived=archived, renamed=renamed)
+
+
+async def run(*, execute: bool) -> None:
+    """Connect to DATABASE_URL and run the sweep."""
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL not set")
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        if execute:
+            async with conn.transaction():
+                report = await sweep_role_data_quality(conn, execute=True)
+        else:
+            report = await sweep_role_data_quality(conn, execute=False)
+
+        archive_counts = Counter(a["status"] for a in report["archived"])
+        rename_counts = Counter(a["status"] for a in report["renamed"])
+        verb = "Swept" if execute else "Dry run — would sweep"
+        logger.info(
+            "%s: %d artifact role(s) archived (%s), %d title(s) normalized (%s)",
+            verb,
+            len(report["archived"]),
+            ", ".join(f"{k}={v}" for k, v in sorted(archive_counts.items())) or "none",
+            len(report["renamed"]),
+            ", ".join(f"{k}={v}" for k, v in sorted(rename_counts.items())) or "none",
+        )
+        if not execute:
+            logger.info("Pass --execute to commit")
+    finally:
+        await conn.close()
+
+
+def main() -> None:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--execute", action="store_true", help="Commit changes (default is dry run)"
+    )
+    args = parser.parse_args()
+    asyncio.run(run(execute=args.execute))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sweep_role_data_quality.py
+++ b/scripts/sweep_role_data_quality.py
@@ -34,6 +34,7 @@ import argparse
 import asyncio
 import os
 from collections import Counter
+from datetime import UTC, datetime
 from typing import Literal, TypedDict
 
 import asyncpg
@@ -64,7 +65,10 @@ def canonical_rename(title: str) -> str | None:
 
 
 ArchiveStatus = Literal["archived", "planned"]
-RenameStatus = Literal["renamed", "merged", "planned"]
+# Dry run distinguishes the two rename outcomes — an in-place UPDATE vs a
+# destructive merge into an existing canonical role — so the risky path is
+# visible before --execute. Execute reports the terminal "renamed" / "merged".
+RenameStatus = Literal["renamed", "merged", "would_rename", "would_merge"]
 
 
 class ArchiveAction(TypedDict):
@@ -118,12 +122,17 @@ WHERE r.archived_at IS NULL
 ORDER BY r.title, r.id
 """
 
-# A same-org active plain role already at the canonical title (excluding self).
+# A same-org active role already at the canonical title (excluding self). Scoped
+# to exactly uq_role_org_title's predicate (jurisdiction_id IS NULL AND
+# archived_at IS NULL) — deliberately NOT also role_type_id IS NULL: the index
+# covers non-jurisdictional roles regardless of role_type, so a *typed* peer at
+# the canonical title would still collide on a bare in-place UPDATE. Detecting it
+# routes the typo through a merge instead (untyped loser folds into the typed
+# winner — the better outcome), never tripping the constraint.
 _CANONICAL_PEER_SQL = """
 SELECT r.id
 FROM roles r
-WHERE r.archived_at IS NULL
-  AND r.role_type_id IS NULL AND r.jurisdiction_id IS NULL
+WHERE r.archived_at IS NULL AND r.jurisdiction_id IS NULL
   AND r.organization_id = $1 AND lower(r.title) = $2 AND r.id <> $3
 ORDER BY r.id
 LIMIT 1
@@ -163,6 +172,10 @@ WHERE ra.role_id = $1 AND ra.archived_at IS NULL
 _REPOINT_ASSIGNMENTS_SQL = "UPDATE role_assignments SET role_id = $1 WHERE role_id = $2"
 _DELETE_ROLE_SQL = "DELETE FROM roles WHERE id = $1"
 
+_LOSER_ROLE_SQL = "SELECT title, notes FROM roles WHERE id = $1"
+_WINNER_NOTES_SQL = "SELECT notes FROM roles WHERE id = $1"
+_APPEND_WINNER_NOTES_SQL = "UPDATE roles SET notes = $2 WHERE id = $1"
+
 
 async def _archive_artifacts(conn: asyncpg.Connection, *, execute: bool) -> list[ArchiveAction]:
     """Archive artifact roles (Guest / Visitor or Guest) and their active assignments."""
@@ -192,6 +205,20 @@ async def _archive_artifacts(conn: asyncpg.Connection, *, execute: bool) -> list
 
 async def _merge_into_canonical(conn: asyncpg.Connection, loser_id: str, winner_id: str) -> None:
     """Fold a typo role into the same-org canonical role (mirrors admin role_merge)."""
+    # Preserve the loser role's notes on the survivor before the hard-delete
+    # (mirrors role_merge; the script is the actor in place of a curator email).
+    loser = await conn.fetchrow(_LOSER_ROLE_SQL, loser_id)
+    if loser is not None and loser["notes"]:
+        winner_notes = await conn.fetchval(_WINNER_NOTES_SQL, winner_id)
+        merge_date = datetime.now(UTC).strftime("%Y-%m-%d")
+        prefix = (
+            f"Merged from {loser['title']} on {merge_date}"
+            " by scripts.sweep_role_data_quality (#304)"
+        )
+        appended = f"{prefix}\n{loser['notes']}"
+        new_notes = f"{winner_notes}\n\n{appended}" if winner_notes else appended
+        await conn.execute(_APPEND_WINNER_NOTES_SQL, winner_id, new_notes)
+
     conflict_pairs = await conn.fetch(_CONFLICT_PAIRS_SQL, loser_id, winner_id)
     await rehome_conflicting_assignment_ancillary(
         conn, [(r["loser_ra"], r["winner_ra"]) for r in conflict_pairs]
@@ -218,7 +245,7 @@ async def _normalize_typos(conn: asyncpg.Connection, *, execute: bool) -> list[R
             "from_title": row["title"],
             "to_title": canonical,
             "target_role_id": peer,
-            "status": "planned",
+            "status": "would_merge" if peer is not None else "would_rename",
         }
         actions.append(action)
         if not execute:

--- a/tests/scripts/test_sweep_role_data_quality.py
+++ b/tests/scripts/test_sweep_role_data_quality.py
@@ -1,0 +1,277 @@
+"""Tests for scripts/sweep_role_data_quality.py (#304).
+
+Data-only sweep over non-jurisdictional free-text roles: archive non-role
+observation artifacts (`Guest`, `Visitor or Guest`) and normalize typo'd titles
+(`Principle` → `Principal`) so they stop orphaning the ``(org, lower(title))``
+match key. Rename merges-if-it-would-collide (never trips ``uq_role_org_title``).
+
+Unit tests cover the pure planners; integration tests (require TEST_DATABASE_URL
++ schema-applied DB) cover the archive/rename/merge flow.
+
+Run via:
+    uv run pytest tests/scripts/test_sweep_role_data_quality.py
+"""
+
+from datetime import date
+
+import pytest
+import pytest_asyncio
+
+from scripts.sweep_role_data_quality import (
+    ARCHIVE_TITLES,
+    RENAME_MAP,
+    canonical_rename,
+    sweep_role_data_quality,
+)
+from src.core.db import generate_id
+
+# ---------------------------------------------------------------------------
+# Pure planners
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        ("Principle", "Principal"),
+        ("principle", "Principal"),  # case-insensitive match key
+        ("  Principle  ", "Principal"),  # whitespace tolerant
+        ("Principal", None),  # already canonical — no-op (idempotent)
+        ("Guest", None),  # archive candidate, not a rename
+        ("Research Analyst", None),  # not in the typo map
+        ("", None),
+    ],
+)
+def test_canonical_rename(title: str, expected: str | None) -> None:
+    assert canonical_rename(title) == expected
+
+
+def test_config_is_lowercased_and_disjoint() -> None:
+    # Match keys are compared lowercased — the config must already be lower.
+    assert all(t == t.lower() for t in ARCHIVE_TITLES)
+    assert all(k == k.lower() for k in RENAME_MAP)
+    # A title is either an archive artifact or a rename source, never both.
+    assert ARCHIVE_TITLES.isdisjoint(RENAME_MAP)
+    # Canonical targets are never themselves typo sources (no rename chains).
+    assert all(v.lower() not in RENAME_MAP for v in RENAME_MAP.values())
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+pytestmark_integration = pytest.mark.integration
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def db(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            yield conn
+        finally:
+            await tr.rollback()
+
+
+async def _org(db) -> str:
+    oid = generate_id()
+    await db.execute("INSERT INTO organizations (id) VALUES ($1)", oid)
+    return oid
+
+
+async def _person(db) -> str:
+    pid = generate_id()
+    await db.execute("INSERT INTO people (id) VALUES ($1)", pid)
+    return pid
+
+
+async def _role(db, org_id: str, title: str) -> str:
+    """A plain non-jurisdictional free-text role (role_type_id/jurisdiction_id NULL)."""
+    rid = generate_id()
+    await db.execute(
+        "INSERT INTO roles (id, organization_id, title) VALUES ($1,$2,$3)",
+        rid,
+        org_id,
+        title,
+    )
+    return rid
+
+
+async def _assign(db, role_id: str, person_id: str, *, start=None) -> str:
+    aid = generate_id()
+    await db.execute(
+        "INSERT INTO role_assignments (id, role_id, person_id, start_date) VALUES ($1,$2,$3,$4)",
+        aid,
+        role_id,
+        person_id,
+        start,
+    )
+    return aid
+
+
+async def _role_state(db, role_id: str):
+    return await db.fetchrow("SELECT title, archived_at FROM roles WHERE id=$1", role_id)
+
+
+async def _active_assign_count(db, role_id: str) -> int:
+    return await db.fetchval(
+        "SELECT count(*) FROM role_assignments WHERE role_id=$1 AND archived_at IS NULL",
+        role_id,
+    )
+
+
+# --- archive path ---------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_dry_run_mutates_nothing(db):
+    org = await _org(db)
+    person = await _person(db)
+    guest = await _role(db, org, "Guest")
+    await _assign(db, guest, person)
+    typo = await _role(db, org, "Principle")
+
+    report = await sweep_role_data_quality(db, execute=False)
+
+    # Reported as planned...
+    archived = {a["role_id"]: a for a in report["archived"]}
+    renamed = {a["role_id"]: a for a in report["renamed"]}
+    assert archived[guest]["status"] == "planned"
+    assert renamed[typo]["status"] == "planned"
+    # ...but nothing changed.
+    assert (await _role_state(db, guest))["archived_at"] is None
+    assert await _active_assign_count(db, guest) == 1
+    assert (await _role_state(db, typo))["title"] == "Principle"
+
+
+@pytest.mark.integration
+async def test_archive_artifact_role_and_assignments(db):
+    org = await _org(db)
+    p1, p2 = await _person(db), await _person(db)
+    guest = await _role(db, org, "Guest")
+    await _assign(db, guest, p1)
+    await _assign(db, guest, p2)
+    visitor = await _role(db, org, "Visitor or Guest")
+    await _assign(db, visitor, p1)
+
+    await sweep_role_data_quality(db, execute=True)
+
+    for rid in (guest, visitor):
+        assert (await _role_state(db, rid))["archived_at"] is not None
+        assert await _active_assign_count(db, rid) == 0
+
+
+@pytest.mark.integration
+async def test_archive_matches_case_insensitively(db):
+    org = await _org(db)
+    guest = await _role(db, org, "guest")  # lowercase observed variant
+    await sweep_role_data_quality(db, execute=True)
+    assert (await _role_state(db, guest))["archived_at"] is not None
+
+
+@pytest.mark.integration
+async def test_non_artifact_role_untouched(db):
+    org = await _org(db)
+    keep = await _role(db, org, "Executive Director")
+    await sweep_role_data_quality(db, execute=True)
+    st = await _role_state(db, keep)
+    assert st["archived_at"] is None and st["title"] == "Executive Director"
+
+
+# --- rename path ----------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_rename_typo_in_place_when_no_collision(db):
+    org = await _org(db)
+    person = await _person(db)
+    typo = await _role(db, org, "Principle")
+    await _assign(db, typo, person)
+
+    await sweep_role_data_quality(db, execute=True)
+
+    st = await _role_state(db, typo)
+    assert st["title"] == "Principal"
+    assert st["archived_at"] is None
+    assert await _active_assign_count(db, typo) == 1  # assignments untouched
+
+
+@pytest.mark.integration
+async def test_rename_is_idempotent(db):
+    org = await _org(db)
+    typo = await _role(db, org, "Principle")
+    await sweep_role_data_quality(db, execute=True)
+    # Second run finds nothing to do — no error, canonical row stays put.
+    report = await sweep_role_data_quality(db, execute=True)
+    assert all(a["role_id"] != typo for a in report["renamed"])
+    assert (await _role_state(db, typo))["title"] == "Principal"
+
+
+@pytest.mark.integration
+async def test_rename_merges_into_existing_canonical_on_collision(db):
+    """Same org already has the canonical role → merge, don't trip uq_role_org_title."""
+    org = await _org(db)
+    p1, p2 = await _person(db), await _person(db)
+    canonical = await _role(db, org, "Principal")
+    await _assign(db, canonical, p1)
+    typo = await _role(db, org, "Principle")
+    await _assign(db, typo, p2)
+
+    report = await sweep_role_data_quality(db, execute=True)
+
+    merged = {a["role_id"]: a for a in report["renamed"]}[typo]
+    assert merged["status"] == "merged"
+    assert merged["target_role_id"] == canonical
+    # Loser role gone; its assignment re-homed onto the canonical role.
+    assert await _role_state(db, typo) is None
+    assert await _active_assign_count(db, canonical) == 2
+
+
+@pytest.mark.integration
+async def test_merge_dedups_same_person_same_start(db):
+    """Colliding assignment identity (person, start_date) folds, never duplicates."""
+    org = await _org(db)
+    person = await _person(db)
+    canonical = await _role(db, org, "Principal")
+    await _assign(db, canonical, person, start=date(2020, 1, 1))
+    typo = await _role(db, org, "Principle")
+    await _assign(db, typo, person, start=date(2020, 1, 1))  # same identity
+
+    await sweep_role_data_quality(db, execute=True)
+
+    assert await _role_state(db, typo) is None
+    assert await _active_assign_count(db, canonical) == 1  # deduped, not doubled
+
+
+@pytest.mark.integration
+async def test_typed_roles_never_swept(db):
+    """Only plain free-text roles are in scope — a typed role matches structurally.
+
+    A typed role titled 'Guest' (an artifact key) or 'Principle' (a typo key) must
+    be left untouched: its match key is ``role_type_id`` + structure, not
+    ``(org, lower(title))``, so the sweep's title rules do not apply.
+    """
+    org = await _org(db)
+    rt_id = generate_id()
+    await db.execute(
+        "INSERT INTO role_types (id, slug, display_name) VALUES ($1,$2,'DQ Sweep Test Type')",
+        rt_id,
+        f"dq_sweep_test_{rt_id.lower()}",
+    )
+    guest = generate_id()
+    typo = generate_id()
+    for rid, title in ((guest, "Guest"), (typo, "Principle")):
+        await db.execute(
+            "INSERT INTO roles (id, organization_id, title, role_type_id) VALUES ($1,$2,$3,$4)",
+            rid,
+            org,
+            title,
+            rt_id,
+        )
+
+    await sweep_role_data_quality(db, execute=True)
+
+    assert (await _role_state(db, guest))["archived_at"] is None
+    typo_st = await _role_state(db, typo)
+    assert typo_st["archived_at"] is None and typo_st["title"] == "Principle"

--- a/tests/scripts/test_sweep_role_data_quality.py
+++ b/tests/scripts/test_sweep_role_data_quality.py
@@ -138,7 +138,7 @@ async def test_dry_run_mutates_nothing(db):
     archived = {a["role_id"]: a for a in report["archived"]}
     renamed = {a["role_id"]: a for a in report["renamed"]}
     assert archived[guest]["status"] == "planned"
-    assert renamed[typo]["status"] == "planned"
+    assert renamed[typo]["status"] == "would_rename"  # dry run distinguishes rename vs merge
     # ...but nothing changed.
     assert (await _role_state(db, guest))["archived_at"] is None
     assert await _active_assign_count(db, guest) == 1
@@ -226,6 +226,72 @@ async def test_rename_merges_into_existing_canonical_on_collision(db):
     # Loser role gone; its assignment re-homed onto the canonical role.
     assert await _role_state(db, typo) is None
     assert await _active_assign_count(db, canonical) == 2
+
+
+@pytest.mark.integration
+async def test_dry_run_flags_a_would_be_merge(db):
+    """A dry run marks a colliding typo 'would_merge' so the destructive path is visible."""
+    org = await _org(db)
+    await _role(db, org, "Principal")
+    typo = await _role(db, org, "Principle")
+
+    report = await sweep_role_data_quality(db, execute=False)
+
+    action = {a["role_id"]: a for a in report["renamed"]}[typo]
+    assert action["status"] == "would_merge"
+    assert await _role_state(db, typo) is not None  # dry run mutated nothing
+
+
+@pytest.mark.integration
+async def test_rename_merges_into_typed_canonical_peer(db):
+    """A typed non-jurisdictional canonical peer is inside uq_role_org_title's scope too
+    (index is WHERE jurisdiction_id IS NULL — role_type irrelevant), so the typo must
+    merge into it, never trip the constraint with a bare in-place UPDATE."""
+    org = await _org(db)
+    p1, p2 = await _person(db), await _person(db)
+    rt_id = generate_id()
+    await db.execute(
+        "INSERT INTO role_types (id, slug, display_name) VALUES ($1,$2,'DQ Sweep Test Type')",
+        rt_id,
+        f"dq_sweep_test_{rt_id.lower()}",
+    )
+    canonical = generate_id()
+    await db.execute(
+        "INSERT INTO roles (id, organization_id, title, role_type_id)"
+        " VALUES ($1,$2,'Principal',$3)",
+        canonical,
+        org,
+        rt_id,
+    )
+    await _assign(db, canonical, p1)
+    typo = await _role(db, org, "Principle")
+    await _assign(db, typo, p2)
+
+    report = await sweep_role_data_quality(db, execute=True)
+
+    merged = {a["role_id"]: a for a in report["renamed"]}[typo]
+    assert merged["status"] == "merged"
+    assert merged["target_role_id"] == canonical
+    # No unique_violation; typo folded into the typed canonical role.
+    assert await _role_state(db, typo) is None
+    assert await _active_assign_count(db, canonical) == 2
+
+
+@pytest.mark.integration
+async def test_merge_appends_loser_notes_to_winner(db):
+    """Merge preserves the loser role's notes on the survivor (mirrors admin role_merge)."""
+    org = await _org(db)
+    canonical = await _role(db, org, "Principal")
+    await db.execute("UPDATE roles SET notes='winner note' WHERE id=$1", canonical)
+    typo = await _role(db, org, "Principle")
+    await db.execute("UPDATE roles SET notes='typo note' WHERE id=$1", typo)
+
+    await sweep_role_data_quality(db, execute=True)
+
+    notes = await db.fetchval("SELECT notes FROM roles WHERE id=$1", canonical)
+    assert "winner note" in notes
+    assert "typo note" in notes
+    assert "Merged from Principle" in notes
 
 
 @pytest.mark.integration

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.16.6"
+version = "0.16.7"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Closes part of #304 (mechanical sweep only — vocabulary judgment calls handed to #266, see [issue comment](https://github.com/CannObserv/power-map/issues/304#issuecomment-5147777267)).

## What
`scripts/sweep_role_data_quality.py` — idempotent dry-run/`--execute`, mirrors `archive_legacy_legislator_roles.py`. Operates **only** on plain free-text roles (`role_type_id IS NULL AND jurisdiction_id IS NULL`), whose match key is `(org, lower(title))` = `uq_role_org_title`.

1. **Archive non-role artifacts** — `Guest` / `Visitor or Guest`: attendance noise that leaks into membership queries. Archives active assignments, then the role (never hard-delete).
2. **Normalize typo'd titles** — `Principle` → `Principal`. Renames in place; when the same org **already** carries the canonical role (would trip `uq_role_org_title`), instead **merges** the typo role in — assignments re-pointed with `(person, start_date)` dedup, role-level ancillary re-homed (#324/#326), loser hard-deleted. Mirrors admin `role_merge`.

## Scope decisions (grounded against prod data)
- `Reseach Analyst` → **dropped**: already archived, 0 active assignments — not an orphan match key.
- `Participant` (42 assigns) → **descoped**: not uniform noise. On WSLCB EMT / Integrator Work Group it's the *only* roster signal; on TAC it co-exists with `Member` as a deliberate observer distinction. Blanket-archive would destroy real data → per-org retype decision for #266.
- bare `Chairman` → **descoped**: mostly Tribal councils where it's the accurate title; a gendered/semantic normalization, not a typo.
- `Ranking Democratic Member` → **descoped**: needs a committee role type (typed-fold), #266 work.

## Prod dry-run
```
3 artifact role(s) archived (planned=3), 5 title(s) normalized (planned=5)
```
= Guest×2 + Visitor or Guest×1, Principle×5 (5 distinct orgs, no collisions → all plain renames).

## Tests
17 (8 unit + 9 integration): pure planner, archive path (incl. case-insensitive + non-artifact untouched), rename-in-place, idempotency, merge-on-collision, `(person, start_date)` dedup, typed-role scope guard.

## Deploy
Script-only; no service behavior change. **`--execute` against prod is a separate operational step — not run yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
