### PR TITLE
#358 feat: clearable typeahead pickers — blank-to-clear + × button

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1189,6 +1189,35 @@ The factory implements:
 | **Escape** | Close dropdown without selection |
 | **Mouse select** | `ul.addEventListener('mousedown')` + `e.preventDefault()` — delegate to `closest('[data-id]')`. `mousedown` is used instead of `click` because mousedown fires first; without `preventDefault`, the input loses focus before `click` fires and the event is swallowed or re-routed in some browsers. |
 | **Scoped IDs** | In `afterSwap`, prefix each `li.id` with the listbox's own `id` to prevent duplicate IDs when two typeaheads are mounted |
+| **Stale-id guard (#358)** | The hidden id is valid only while the visible text equals the label of the last selection (seeded from the server-rendered value). Any input that diverges — emptying the box, or editing it — clears the hidden id, so blanking the search box can never silently re-submit the previous selection. |
+
+### Clearing a selection (#358)
+
+An optional visible "×" button lets a user unset an **optional** picker (e.g. a role's jurisdiction, an event's linked entity) without editing the text. Required pickers need no button — blanking + submit surfaces the existing "select an X" validation error.
+
+Wrap the visible input in `.typeahead-input-wrap` (so the button centres over the input, not a label above it) and pass `clearButtonId`:
+
+```html
+<div class="typeahead-input-wrap">
+  <input id="jurisdiction-search" ...>
+  <button type="button" class="typeahead-clear" id="jurisdiction-clear"
+          data-typeahead-clear aria-label="Clear jurisdiction">&times;</button>
+</div>
+<input type="hidden" name="jurisdiction_id" id="jurisdiction-id-hidden" value="...">
+```
+
+```javascript
+window.initTypeaheadCombobox({
+  inputId: 'jurisdiction-search',
+  listboxId: 'jurisdiction-search-results',
+  hiddenId: 'jurisdiction-id-hidden',
+  clearButtonId: 'jurisdiction-clear',   // optional — omit for required pickers
+  onClear: () => { /* optional — react to a cleared selection */ },
+});
+```
+
+- The `×` button clears text + hidden id, closes the dropdown, and refocuses the input.
+- `onClear()` fires (from either clear path) only when a non-empty selection was actually dropped — use it to reset dependent UI (e.g. a relationship phrase preview). Do **not** reuse `onSelect('')` for this; `onSelect` consumers that navigate on select (e.g. the merge target picker) must not fire on a clear.
 
 ---
 

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1201,10 +1201,13 @@ Wrap the visible input in `.typeahead-input-wrap` (so the button centres over th
 <div class="typeahead-input-wrap">
   <input id="jurisdiction-search" ...>
   <button type="button" class="typeahead-clear" id="jurisdiction-clear"
-          data-typeahead-clear aria-label="Clear jurisdiction">&times;</button>
+          data-typeahead-clear aria-label="Clear jurisdiction"
+          {% if not sel_jurisdiction_id %}style="display:none"{% endif %}>&times;</button>
 </div>
 <input type="hidden" name="jurisdiction_id" id="jurisdiction-id-hidden" value="...">
 ```
+
+Seed `style="display:none"` on the button when the field renders empty (mirror the hidden id's condition): the factory reconciles visibility on mount, but the inline seed avoids a pre-hydration flash of a `×` with nothing to clear.
 
 ```javascript
 window.initTypeaheadCombobox({

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1216,7 +1216,7 @@ window.initTypeaheadCombobox({
 });
 ```
 
-- The `×` button clears text + hidden id, closes the dropdown, and refocuses the input.
+- The `×` button clears text + hidden id, closes the dropdown, and refocuses the input. The factory shows it only while a selection exists (hidden id non-empty), so an empty picker carries no clear affordance.
 - `onClear()` fires (from either clear path) only when a non-empty selection was actually dropped — use it to reset dependent UI (e.g. a relationship phrase preview). Do **not** reuse `onSelect('')` for this; `onSelect` consumers that navigate on select (e.g. the merge target picker) must not fire on a clear.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.16.7"
+version = "0.16.8"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/static/admin/admin.css
+++ b/src/static/admin/admin.css
@@ -300,6 +300,14 @@ a.citation-indicator:hover { text-decoration: underline; }
 .typeahead-results li { padding: var(--space-2) var(--space-3); cursor: pointer; font-size: var(--font-size-sm); border-bottom: 1px solid var(--color-border); }
 .typeahead-results li:last-child { border-bottom: none; }
 .typeahead-results li:hover, .typeahead-results li.is-active { background: var(--color-surface-0); }
+/* "×" clear button for a typeahead selection (#358). Wrap the visible search
+   input in .typeahead-input-wrap so the button centres over the input (not the
+   label above it), overlaying its trailing edge. */
+.typeahead-input-wrap { position: relative; }
+.typeahead-input-wrap > input { padding-right: 1.75rem; }
+.typeahead-clear { position: absolute; right: var(--space-2); top: 50%; transform: translateY(-50%); display: flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem; padding: 0; border: none; background: transparent; color: var(--color-text-muted); font-size: var(--font-size-lg); line-height: 1; cursor: pointer; border-radius: var(--radius-sm); }
+.typeahead-clear:hover { color: var(--color-text); background: var(--color-surface-0); }
+.typeahead-clear:focus-visible { outline: 2px solid var(--color-focus, var(--color-border)); outline-offset: 1px; }
 
 /* Pill toggle switch */
 .toggle { position: relative; display: inline-flex; align-items: center; cursor: pointer; gap: var(--space-3); }

--- a/src/static/admin/event-form-row.js
+++ b/src/static/admin/event-form-row.js
@@ -56,6 +56,7 @@
       inputId: 'linked-entity-search-' + uid,
       listboxId: 'linked-entity-results-' + uid,
       hiddenId: 'linked-entity-id-' + uid,
+      clearButtonId: 'linked-entity-clear-' + uid,
     });
 
     syncSection();

--- a/src/static/admin/event-form-row.js
+++ b/src/static/admin/event-form-row.js
@@ -44,19 +44,24 @@
       search.disabled = !linkedTypeSel.value;
     }
 
-    eventTypeSel.addEventListener('change', syncSection);
-    linkedTypeSel.addEventListener('change', function () {
-      // Switching scope invalidates any prior person/org selection.
-      search.value = '';
-      hidden.value = '';
-      syncSearchDisabled();
-    });
-
-    window.initTypeaheadCombobox({
+    var combo = window.initTypeaheadCombobox({
       inputId: 'linked-entity-search-' + uid,
       listboxId: 'linked-entity-results-' + uid,
       hiddenId: 'linked-entity-id-' + uid,
       clearButtonId: 'linked-entity-clear-' + uid,
+    });
+
+    eventTypeSel.addEventListener('change', syncSection);
+    linkedTypeSel.addEventListener('change', function () {
+      // Switching scope invalidates any prior person/org selection. Route the
+      // clear through the factory so the "×" visibility stays in sync (#358 CR);
+      // fall back to a direct clear if an older factory returns no handle.
+      if (combo && combo.clear) combo.clear();
+      else {
+        search.value = '';
+        hidden.value = '';
+      }
+      syncSearchDisabled();
     });
 
     syncSection();

--- a/src/static/admin/person-name-row-typeahead.js
+++ b/src/static/admin/person-name-row-typeahead.js
@@ -32,16 +32,19 @@
       inputId: 'locale-search-display-' + uid,
       listboxId: 'locale-search-results-' + uid,
       hiddenId: 'locale-hidden-' + uid,
+      clearButtonId: 'locale-clear-' + uid,
     });
     window.initTypeaheadCombobox({
       inputId: 'script-search-display-' + uid,
       listboxId: 'script-search-results-' + uid,
       hiddenId: 'script-hidden-' + uid,
+      clearButtonId: 'script-clear-' + uid,
     });
     window.initTypeaheadCombobox({
       inputId: 'reading-of-display-' + uid,
       listboxId: 'reading-of-results-' + uid,
       hiddenId: 'reading-of-hidden-' + uid,
+      clearButtonId: 'reading-of-clear-' + uid,
     });
     // Reading-of block visibility: shown only when name_type is one of
     // {reading, romanization, mrz} — matches the person_names.name_type

--- a/src/static/admin/typeahead-combobox.js
+++ b/src/static/admin/typeahead-combobox.js
@@ -2,8 +2,11 @@
  * typeahead-combobox.js — factory for HTMX-backed typeahead combobox inputs.
  *
  * Usage (inline <script> in an HTMX partial, runs after the factory is loaded):
- *   window.initTypeaheadCombobox({ inputId, listboxId, hiddenId, onSelect });
+ *   window.initTypeaheadCombobox({ inputId, listboxId, hiddenId, clearButtonId, onSelect, onClear });
  * onSelect (optional): callback(selectedId) invoked when an item is selected.
+ * clearButtonId (optional): id of a "×" button that clears the selection.
+ * onClear (optional): callback() invoked when a non-empty selection is cleared
+ *   (via the clear button, an emptied input, or text edited away from the label).
  *
  * The input must have:
  *   hx-get="<search endpoint>"
@@ -19,17 +22,28 @@
  *   causes mouse selection to silently fail in some browsers: mousedown fires
  *   first, moves focus away from the input, and the subsequent click may be
  *   swallowed or re-routed before the listbox handler can run.
+ *
+ * Stale-id guard (#358): the hidden id is valid only while the visible text
+ * exactly equals the label of the last selection.  Any input that diverges from
+ * that label (emptying the box, or editing it) clears the hidden id — otherwise
+ * blanking the search box would silently re-submit the previously-selected id.
  */
 window.initTypeaheadCombobox = function initTypeaheadCombobox({
   inputId,
   listboxId,
   hiddenId,
+  clearButtonId,
   onSelect,
+  onClear,
 }) {
   var inp = document.getElementById(inputId);
   var ul = document.getElementById(listboxId);
   var hidden = document.getElementById(hiddenId);
+  var clearBtn = clearButtonId ? document.getElementById(clearButtonId) : null;
   var activeIdx = -1;
+  // The label the hidden id currently corresponds to.  Seeded from the
+  // server-rendered value so editing an existing selection invalidates it.
+  var selectedLabel = inp.value;
 
   function getItems() {
     return Array.from(ul.querySelectorAll('li[data-id]'));
@@ -48,8 +62,21 @@ window.initTypeaheadCombobox = function initTypeaheadCombobox({
   function selectItem(li) {
     hidden.value = li.dataset.id;
     inp.value = li.dataset.label;
+    selectedLabel = li.dataset.label;
     closeDropdown();
     if (onSelect) onSelect(li.dataset.id);
+  }
+
+  // Clear the current selection.  `focus` refocuses the input (clear-button
+  // path); onClear fires only when something was actually cleared.
+  function clearSelection(focus) {
+    var had = hidden.value !== '';
+    hidden.value = '';
+    inp.value = '';
+    selectedLabel = '';
+    closeDropdown();
+    if (focus) inp.focus();
+    if (had && onClear) onClear();
   }
 
   function openDropdown() {
@@ -120,4 +147,24 @@ window.initTypeaheadCombobox = function initTypeaheadCombobox({
     e.preventDefault();
     selectItem(li);
   });
+
+  // Stale-id guard (#358): once the visible text diverges from the label the
+  // hidden id was set for, the id no longer describes what the user sees — drop
+  // it so the form can't silently re-submit a stale selection.  Fires alongside
+  // (not instead of) HTMX's own input-triggered search.
+  inp.addEventListener('input', function () {
+    if (inp.value !== selectedLabel && hidden.value !== '') {
+      hidden.value = '';
+      selectedLabel = '';
+      if (onClear) onClear();
+    }
+  });
+
+  // Optional visible "×" clear button.
+  if (clearBtn) {
+    clearBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      clearSelection(true);
+    });
+  }
 };

--- a/src/static/admin/typeahead-combobox.js
+++ b/src/static/admin/typeahead-combobox.js
@@ -4,7 +4,8 @@
  * Usage (inline <script> in an HTMX partial, runs after the factory is loaded):
  *   window.initTypeaheadCombobox({ inputId, listboxId, hiddenId, clearButtonId, onSelect, onClear });
  * onSelect (optional): callback(selectedId) invoked when an item is selected.
- * clearButtonId (optional): id of a "×" button that clears the selection.
+ * clearButtonId (optional): id of a "×" button that clears the selection. The
+ *   factory shows it only while a selection exists (hidden id non-empty).
  * onClear (optional): callback() invoked when a non-empty selection is cleared
  *   (via the clear button, an emptied input, or text edited away from the label).
  *
@@ -59,11 +60,18 @@ window.initTypeaheadCombobox = function initTypeaheadCombobox({
     inp.setAttribute('aria-activedescendant', activeIdx >= 0 ? items[activeIdx].id || '' : '');
   }
 
+  // Show the "×" only while a selection exists — an empty picker has nothing
+  // to clear, so the affordance would be noise (#358 CR).
+  function syncClearBtn() {
+    if (clearBtn) clearBtn.style.display = hidden.value ? '' : 'none';
+  }
+
   function selectItem(li) {
     hidden.value = li.dataset.id;
     inp.value = li.dataset.label;
     selectedLabel = li.dataset.label;
     closeDropdown();
+    syncClearBtn();
     if (onSelect) onSelect(li.dataset.id);
   }
 
@@ -75,6 +83,7 @@ window.initTypeaheadCombobox = function initTypeaheadCombobox({
     inp.value = '';
     selectedLabel = '';
     closeDropdown();
+    syncClearBtn();
     if (focus) inp.focus();
     if (had && onClear) onClear();
   }
@@ -156,6 +165,7 @@ window.initTypeaheadCombobox = function initTypeaheadCombobox({
     if (inp.value !== selectedLabel && hidden.value !== '') {
       hidden.value = '';
       selectedLabel = '';
+      syncClearBtn();
       if (onClear) onClear();
     }
   });
@@ -167,4 +177,7 @@ window.initTypeaheadCombobox = function initTypeaheadCombobox({
       clearSelection(true);
     });
   }
+
+  // Reflect the server-rendered selection state on mount.
+  syncClearBtn();
 };

--- a/src/static/admin/typeahead-combobox.js
+++ b/src/static/admin/typeahead-combobox.js
@@ -180,4 +180,13 @@ window.initTypeaheadCombobox = function initTypeaheadCombobox({
 
   // Reflect the server-rendered selection state on mount.
   syncClearBtn();
+
+  // Handle for callers that clear a selection outside the factory's own inputs
+  // (e.g. the event row nulls its linked entity on a scope switch) so the hidden
+  // id, dropdown, and "×" visibility all stay in sync (#358 CR).
+  return {
+    clear: function () {
+      clearSelection(false);
+    },
+  };
 };

--- a/src/templates/admin/jurisdictions/partials/_relationship_form_row.html
+++ b/src/templates/admin/jurisdictions/partials/_relationship_form_row.html
@@ -115,6 +115,7 @@
         listboxId: 'rel-target-results-new',
         hiddenId: 'rel-target-id-new',
         onSelect: updatePhrase,
+        onClear: updatePhrase,
       });
     }
     updatePhrase();

--- a/src/templates/admin/people/partials/_name_metadata_fields.html
+++ b/src/templates/admin/people/partials/_name_metadata_fields.html
@@ -39,52 +39,50 @@
 </div>
 {# Locale typeahead — display input + hidden code value + listbox #}
 <div class="form-group" style="margin-bottom:0;position:relative;min-width:9rem">
-  <label style="font-size:0.75rem;display:block">Locale (BCP-47)
-    <span class="typeahead-input-wrap" style="display:block">
-      <input id="locale-search-display-{{ _uid }}" type="text" autocomplete="off"
-             placeholder="e.g. en, en-US, ja-JP"
-             value="{{ n.locale if n and n.locale else '' }}"
-             hx-get="/admin/people/_locale_search"
-             hx-trigger="input changed delay:200ms"
-             hx-target="#locale-search-results-{{ _uid }}"
-             hx-swap="innerHTML"
-             hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
-             aria-label="Locale"
-             role="combobox"
-             aria-expanded="false"
-             aria-haspopup="listbox"
-             aria-controls="locale-search-results-{{ _uid }}"
-             aria-autocomplete="list">
-      <button type="button" class="typeahead-clear" id="locale-clear-{{ _uid }}"
-              data-typeahead-clear aria-label="Clear locale">&times;</button>
-    </span>
-  </label>
+  <label for="locale-search-display-{{ _uid }}" style="font-size:0.75rem;display:block">Locale (BCP-47)</label>
+  <div class="typeahead-input-wrap">
+    <input id="locale-search-display-{{ _uid }}" type="text" autocomplete="off"
+           placeholder="e.g. en, en-US, ja-JP"
+           value="{{ n.locale if n and n.locale else '' }}"
+           hx-get="/admin/people/_locale_search"
+           hx-trigger="input changed delay:200ms"
+           hx-target="#locale-search-results-{{ _uid }}"
+           hx-swap="innerHTML"
+           hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
+           aria-label="Locale"
+           role="combobox"
+           aria-expanded="false"
+           aria-haspopup="listbox"
+           aria-controls="locale-search-results-{{ _uid }}"
+           aria-autocomplete="list">
+    <button type="button" class="typeahead-clear" id="locale-clear-{{ _uid }}"
+            data-typeahead-clear aria-label="Clear locale">&times;</button>
+  </div>
   <input type="hidden" name="locale" id="locale-hidden-{{ _uid }}"
          value="{{ n.locale if n and n.locale else '' }}">
   <ul id="locale-search-results-{{ _uid }}" class="typeahead-results" role="listbox"></ul>
 </div>
 {# Script typeahead — same shape against iso15924_scripts #}
 <div class="form-group" style="margin-bottom:0;position:relative;min-width:9rem">
-  <label style="font-size:0.75rem;display:block">Script (ISO 15924)
-    <span class="typeahead-input-wrap" style="display:block">
-      <input id="script-search-display-{{ _uid }}" type="text" autocomplete="off"
-             placeholder="e.g. Latn, Jpan, Cyrl"
-             value="{{ n.script if n and n.script else '' }}"
-             hx-get="/admin/people/_script_search"
-             hx-trigger="input changed delay:200ms"
-             hx-target="#script-search-results-{{ _uid }}"
-             hx-swap="innerHTML"
-             hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
-             aria-label="Script"
-             role="combobox"
-             aria-expanded="false"
-             aria-haspopup="listbox"
-             aria-controls="script-search-results-{{ _uid }}"
-             aria-autocomplete="list">
-      <button type="button" class="typeahead-clear" id="script-clear-{{ _uid }}"
-              data-typeahead-clear aria-label="Clear script">&times;</button>
-    </span>
-  </label>
+  <label for="script-search-display-{{ _uid }}" style="font-size:0.75rem;display:block">Script (ISO 15924)</label>
+  <div class="typeahead-input-wrap">
+    <input id="script-search-display-{{ _uid }}" type="text" autocomplete="off"
+           placeholder="e.g. Latn, Jpan, Cyrl"
+           value="{{ n.script if n and n.script else '' }}"
+           hx-get="/admin/people/_script_search"
+           hx-trigger="input changed delay:200ms"
+           hx-target="#script-search-results-{{ _uid }}"
+           hx-swap="innerHTML"
+           hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
+           aria-label="Script"
+           role="combobox"
+           aria-expanded="false"
+           aria-haspopup="listbox"
+           aria-controls="script-search-results-{{ _uid }}"
+           aria-autocomplete="list">
+    <button type="button" class="typeahead-clear" id="script-clear-{{ _uid }}"
+            data-typeahead-clear aria-label="Clear script">&times;</button>
+  </div>
   <input type="hidden" name="script" id="script-hidden-{{ _uid }}"
          value="{{ n.script if n and n.script else '' }}">
   <ul id="script-search-results-{{ _uid }}" class="typeahead-results" role="listbox"></ul>
@@ -94,26 +92,25 @@
 {% set _is_reading_type = n and n.name_type in ('reading','romanization','mrz') %}
 <div id="reading-of-block-{{ _uid }}" class="form-group"
      style="margin-bottom:0;position:relative;min-width:11rem;{% if not _is_reading_type %}display:none;{% endif %}">
-  <label style="font-size:0.75rem;display:block">Reading of
-    <span class="typeahead-input-wrap" style="display:block">
-      <input id="reading-of-display-{{ _uid }}" type="text" autocomplete="off"
-             placeholder="Visual row this reading transliterates"
-             value="{{ n.reading_of_name if n and n.reading_of_name else '' }}"
-             hx-get="/admin/people/{{ person_id }}/_reading_target_search"
-             hx-trigger="input changed delay:200ms"
-             hx-target="#reading-of-results-{{ _uid }}"
-             hx-swap="innerHTML"
-             hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
-             aria-label="Reading of"
-             role="combobox"
-             aria-expanded="false"
-             aria-haspopup="listbox"
-             aria-controls="reading-of-results-{{ _uid }}"
-             aria-autocomplete="list">
-      <button type="button" class="typeahead-clear" id="reading-of-clear-{{ _uid }}"
-              data-typeahead-clear aria-label="Clear reading-of target">&times;</button>
-    </span>
-  </label>
+  <label for="reading-of-display-{{ _uid }}" style="font-size:0.75rem;display:block">Reading of</label>
+  <div class="typeahead-input-wrap">
+    <input id="reading-of-display-{{ _uid }}" type="text" autocomplete="off"
+           placeholder="Visual row this reading transliterates"
+           value="{{ n.reading_of_name if n and n.reading_of_name else '' }}"
+           hx-get="/admin/people/{{ person_id }}/_reading_target_search"
+           hx-trigger="input changed delay:200ms"
+           hx-target="#reading-of-results-{{ _uid }}"
+           hx-swap="innerHTML"
+           hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
+           aria-label="Reading of"
+           role="combobox"
+           aria-expanded="false"
+           aria-haspopup="listbox"
+           aria-controls="reading-of-results-{{ _uid }}"
+           aria-autocomplete="list">
+    <button type="button" class="typeahead-clear" id="reading-of-clear-{{ _uid }}"
+            data-typeahead-clear aria-label="Clear reading-of target">&times;</button>
+  </div>
   <input type="hidden" name="reading_of_id" id="reading-of-hidden-{{ _uid }}"
          value="{{ n.reading_of_id if n and n.reading_of_id else '' }}">
   <ul id="reading-of-results-{{ _uid }}" class="typeahead-results" role="listbox"></ul>

--- a/src/templates/admin/people/partials/_name_metadata_fields.html
+++ b/src/templates/admin/people/partials/_name_metadata_fields.html
@@ -40,20 +40,24 @@
 {# Locale typeahead — display input + hidden code value + listbox #}
 <div class="form-group" style="margin-bottom:0;position:relative;min-width:9rem">
   <label style="font-size:0.75rem;display:block">Locale (BCP-47)
-    <input id="locale-search-display-{{ _uid }}" type="text" autocomplete="off"
-           placeholder="e.g. en, en-US, ja-JP"
-           value="{{ n.locale if n and n.locale else '' }}"
-           hx-get="/admin/people/_locale_search"
-           hx-trigger="input changed delay:200ms"
-           hx-target="#locale-search-results-{{ _uid }}"
-           hx-swap="innerHTML"
-           hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
-           aria-label="Locale"
-           role="combobox"
-           aria-expanded="false"
-           aria-haspopup="listbox"
-           aria-controls="locale-search-results-{{ _uid }}"
-           aria-autocomplete="list">
+    <span class="typeahead-input-wrap" style="display:block">
+      <input id="locale-search-display-{{ _uid }}" type="text" autocomplete="off"
+             placeholder="e.g. en, en-US, ja-JP"
+             value="{{ n.locale if n and n.locale else '' }}"
+             hx-get="/admin/people/_locale_search"
+             hx-trigger="input changed delay:200ms"
+             hx-target="#locale-search-results-{{ _uid }}"
+             hx-swap="innerHTML"
+             hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
+             aria-label="Locale"
+             role="combobox"
+             aria-expanded="false"
+             aria-haspopup="listbox"
+             aria-controls="locale-search-results-{{ _uid }}"
+             aria-autocomplete="list">
+      <button type="button" class="typeahead-clear" id="locale-clear-{{ _uid }}"
+              data-typeahead-clear aria-label="Clear locale">&times;</button>
+    </span>
   </label>
   <input type="hidden" name="locale" id="locale-hidden-{{ _uid }}"
          value="{{ n.locale if n and n.locale else '' }}">
@@ -62,20 +66,24 @@
 {# Script typeahead — same shape against iso15924_scripts #}
 <div class="form-group" style="margin-bottom:0;position:relative;min-width:9rem">
   <label style="font-size:0.75rem;display:block">Script (ISO 15924)
-    <input id="script-search-display-{{ _uid }}" type="text" autocomplete="off"
-           placeholder="e.g. Latn, Jpan, Cyrl"
-           value="{{ n.script if n and n.script else '' }}"
-           hx-get="/admin/people/_script_search"
-           hx-trigger="input changed delay:200ms"
-           hx-target="#script-search-results-{{ _uid }}"
-           hx-swap="innerHTML"
-           hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
-           aria-label="Script"
-           role="combobox"
-           aria-expanded="false"
-           aria-haspopup="listbox"
-           aria-controls="script-search-results-{{ _uid }}"
-           aria-autocomplete="list">
+    <span class="typeahead-input-wrap" style="display:block">
+      <input id="script-search-display-{{ _uid }}" type="text" autocomplete="off"
+             placeholder="e.g. Latn, Jpan, Cyrl"
+             value="{{ n.script if n and n.script else '' }}"
+             hx-get="/admin/people/_script_search"
+             hx-trigger="input changed delay:200ms"
+             hx-target="#script-search-results-{{ _uid }}"
+             hx-swap="innerHTML"
+             hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
+             aria-label="Script"
+             role="combobox"
+             aria-expanded="false"
+             aria-haspopup="listbox"
+             aria-controls="script-search-results-{{ _uid }}"
+             aria-autocomplete="list">
+      <button type="button" class="typeahead-clear" id="script-clear-{{ _uid }}"
+              data-typeahead-clear aria-label="Clear script">&times;</button>
+    </span>
   </label>
   <input type="hidden" name="script" id="script-hidden-{{ _uid }}"
          value="{{ n.script if n and n.script else '' }}">
@@ -87,20 +95,24 @@
 <div id="reading-of-block-{{ _uid }}" class="form-group"
      style="margin-bottom:0;position:relative;min-width:11rem;{% if not _is_reading_type %}display:none;{% endif %}">
   <label style="font-size:0.75rem;display:block">Reading of
-    <input id="reading-of-display-{{ _uid }}" type="text" autocomplete="off"
-           placeholder="Visual row this reading transliterates"
-           value="{{ n.reading_of_name if n and n.reading_of_name else '' }}"
-           hx-get="/admin/people/{{ person_id }}/_reading_target_search"
-           hx-trigger="input changed delay:200ms"
-           hx-target="#reading-of-results-{{ _uid }}"
-           hx-swap="innerHTML"
-           hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
-           aria-label="Reading of"
-           role="combobox"
-           aria-expanded="false"
-           aria-haspopup="listbox"
-           aria-controls="reading-of-results-{{ _uid }}"
-           aria-autocomplete="list">
+    <span class="typeahead-input-wrap" style="display:block">
+      <input id="reading-of-display-{{ _uid }}" type="text" autocomplete="off"
+             placeholder="Visual row this reading transliterates"
+             value="{{ n.reading_of_name if n and n.reading_of_name else '' }}"
+             hx-get="/admin/people/{{ person_id }}/_reading_target_search"
+             hx-trigger="input changed delay:200ms"
+             hx-target="#reading-of-results-{{ _uid }}"
+             hx-swap="innerHTML"
+             hx-vals='js:{q: (event && event.target ? event.target.value : "")}'
+             aria-label="Reading of"
+             role="combobox"
+             aria-expanded="false"
+             aria-haspopup="listbox"
+             aria-controls="reading-of-results-{{ _uid }}"
+             aria-autocomplete="list">
+      <button type="button" class="typeahead-clear" id="reading-of-clear-{{ _uid }}"
+              data-typeahead-clear aria-label="Clear reading-of target">&times;</button>
+    </span>
   </label>
   <input type="hidden" name="reading_of_id" id="reading-of-hidden-{{ _uid }}"
          value="{{ n.reading_of_id if n and n.reading_of_id else '' }}">

--- a/src/templates/admin/people/partials/_name_metadata_fields.html
+++ b/src/templates/admin/people/partials/_name_metadata_fields.html
@@ -56,7 +56,8 @@
            aria-controls="locale-search-results-{{ _uid }}"
            aria-autocomplete="list">
     <button type="button" class="typeahead-clear" id="locale-clear-{{ _uid }}"
-            data-typeahead-clear aria-label="Clear locale">&times;</button>
+            data-typeahead-clear aria-label="Clear locale"
+            {% if not (n and n.locale) %}style="display:none"{% endif %}>&times;</button>
   </div>
   <input type="hidden" name="locale" id="locale-hidden-{{ _uid }}"
          value="{{ n.locale if n and n.locale else '' }}">
@@ -81,7 +82,8 @@
            aria-controls="script-search-results-{{ _uid }}"
            aria-autocomplete="list">
     <button type="button" class="typeahead-clear" id="script-clear-{{ _uid }}"
-            data-typeahead-clear aria-label="Clear script">&times;</button>
+            data-typeahead-clear aria-label="Clear script"
+            {% if not (n and n.script) %}style="display:none"{% endif %}>&times;</button>
   </div>
   <input type="hidden" name="script" id="script-hidden-{{ _uid }}"
          value="{{ n.script if n and n.script else '' }}">
@@ -109,7 +111,8 @@
            aria-controls="reading-of-results-{{ _uid }}"
            aria-autocomplete="list">
     <button type="button" class="typeahead-clear" id="reading-of-clear-{{ _uid }}"
-            data-typeahead-clear aria-label="Clear reading-of target">&times;</button>
+            data-typeahead-clear aria-label="Clear reading-of target"
+            {% if not (n and n.reading_of_id) %}style="display:none"{% endif %}>&times;</button>
   </div>
   <input type="hidden" name="reading_of_id" id="reading-of-hidden-{{ _uid }}"
          value="{{ n.reading_of_id if n and n.reading_of_id else '' }}">

--- a/src/templates/admin/roles/form.html
+++ b/src/templates/admin/roles/form.html
@@ -50,20 +50,24 @@
       <div id="structural-jurisdictional" {% if not v.get('role_type_id') %}hidden{% endif %}>
         <div class="form-group" style="position:relative">
           <label for="jurisdiction-search">Jurisdiction</label>
-          <input id="jurisdiction-search" type="text" autocomplete="off"
-                 placeholder="Type to search…"
-                 value="{{ v.get('jurisdiction_name') or '' }}"
-                 hx-get="/admin/jurisdictions/search/"
-                 hx-trigger="input changed delay:200ms"
-                 hx-target="#jurisdiction-search-results"
-                 hx-swap="innerHTML"
-                 hx-params="q"
-                 name="q"
-                 role="combobox"
-                 aria-expanded="false"
-                 aria-haspopup="listbox"
-                 aria-controls="jurisdiction-search-results"
-                 aria-autocomplete="list">
+          <div class="typeahead-input-wrap">
+            <input id="jurisdiction-search" type="text" autocomplete="off"
+                   placeholder="Type to search…"
+                   value="{{ v.get('jurisdiction_name') or '' }}"
+                   hx-get="/admin/jurisdictions/search/"
+                   hx-trigger="input changed delay:200ms"
+                   hx-target="#jurisdiction-search-results"
+                   hx-swap="innerHTML"
+                   hx-params="q"
+                   name="q"
+                   role="combobox"
+                   aria-expanded="false"
+                   aria-haspopup="listbox"
+                   aria-controls="jurisdiction-search-results"
+                   aria-autocomplete="list">
+            <button type="button" class="typeahead-clear" id="jurisdiction-clear"
+                    data-typeahead-clear aria-label="Clear jurisdiction">&times;</button>
+          </div>
           <input type="hidden" name="jurisdiction_id" id="jurisdiction-id-hidden"
                  value="{{ v.get('jurisdiction_id') or '' }}">
           <ul id="jurisdiction-search-results" class="typeahead-results" role="listbox"></ul>
@@ -112,6 +116,7 @@
         inputId: 'jurisdiction-search',
         listboxId: 'jurisdiction-search-results',
         hiddenId: 'jurisdiction-id-hidden',
+        clearButtonId: 'jurisdiction-clear',
       });
     }
   })();

--- a/src/templates/admin/roles/form.html
+++ b/src/templates/admin/roles/form.html
@@ -66,7 +66,8 @@
                    aria-controls="jurisdiction-search-results"
                    aria-autocomplete="list">
             <button type="button" class="typeahead-clear" id="jurisdiction-clear"
-                    data-typeahead-clear aria-label="Clear jurisdiction">&times;</button>
+                    data-typeahead-clear aria-label="Clear jurisdiction"
+                    {% if not v.get('jurisdiction_id') %}style="display:none"{% endif %}>&times;</button>
           </div>
           <input type="hidden" name="jurisdiction_id" id="jurisdiction-id-hidden"
                  value="{{ v.get('jurisdiction_id') or '' }}">

--- a/src/templates/admin/roles/partials/_structural_form.html
+++ b/src/templates/admin/roles/partials/_structural_form.html
@@ -43,7 +43,8 @@
                  aria-controls="structural-jurisdiction-results"
                  aria-autocomplete="list">
           <button type="button" class="typeahead-clear" id="structural-jurisdiction-clear"
-                  data-typeahead-clear aria-label="Clear jurisdiction">&times;</button>
+                  data-typeahead-clear aria-label="Clear jurisdiction"
+                  {% if not sel_jurisdiction_id %}style="display:none"{% endif %}>&times;</button>
         </div>
         <input type="hidden" name="jurisdiction_id" id="structural-jurisdiction-id"
                value="{{ sel_jurisdiction_id or '' }}">

--- a/src/templates/admin/roles/partials/_structural_form.html
+++ b/src/templates/admin/roles/partials/_structural_form.html
@@ -27,20 +27,24 @@
     <div id="structural-jurisdictional" {% if not sel_role_type_id %}hidden{% endif %}>
       <div class="form-group" style="position:relative">
         <label for="structural-jurisdiction-search">Jurisdiction</label>
-        <input id="structural-jurisdiction-search" type="text" autocomplete="off"
-               placeholder="Type to search…"
-               value="{{ sel_jurisdiction_name or '' }}"
-               hx-get="/admin/jurisdictions/search/"
-               hx-trigger="input changed delay:200ms"
-               hx-target="#structural-jurisdiction-results"
-               hx-swap="innerHTML"
-               hx-params="q"
-               name="q"
-               role="combobox"
-               aria-expanded="false"
-               aria-haspopup="listbox"
-               aria-controls="structural-jurisdiction-results"
-               aria-autocomplete="list">
+        <div class="typeahead-input-wrap">
+          <input id="structural-jurisdiction-search" type="text" autocomplete="off"
+                 placeholder="Type to search…"
+                 value="{{ sel_jurisdiction_name or '' }}"
+                 hx-get="/admin/jurisdictions/search/"
+                 hx-trigger="input changed delay:200ms"
+                 hx-target="#structural-jurisdiction-results"
+                 hx-swap="innerHTML"
+                 hx-params="q"
+                 name="q"
+                 role="combobox"
+                 aria-expanded="false"
+                 aria-haspopup="listbox"
+                 aria-controls="structural-jurisdiction-results"
+                 aria-autocomplete="list">
+          <button type="button" class="typeahead-clear" id="structural-jurisdiction-clear"
+                  data-typeahead-clear aria-label="Clear jurisdiction">&times;</button>
+        </div>
         <input type="hidden" name="jurisdiction_id" id="structural-jurisdiction-id"
                value="{{ sel_jurisdiction_id or '' }}">
         <ul id="structural-jurisdiction-results" class="typeahead-results" role="listbox"></ul>
@@ -78,6 +82,7 @@
           inputId: 'structural-jurisdiction-search',
           listboxId: 'structural-jurisdiction-results',
           hiddenId: 'structural-jurisdiction-id',
+          clearButtonId: 'structural-jurisdiction-clear',
         });
       }
     })();

--- a/src/templates/admin/shared/_event_form_row.html
+++ b/src/templates/admin/shared/_event_form_row.html
@@ -120,7 +120,8 @@
                      aria-controls="linked-entity-results-{{ _le_key }}"
                      aria-autocomplete="list">
               <button type="button" class="typeahead-clear" id="linked-entity-clear-{{ _le_key }}"
-                      data-typeahead-clear aria-label="Clear linked entity">&times;</button>
+                      data-typeahead-clear aria-label="Clear linked entity"
+                      {% if not (ev and ev.linked_entity_id) %}style="display:none"{% endif %}>&times;</button>
             </div>
             <input type="hidden" name="linked_entity_id" id="linked-entity-id-{{ _le_key }}"
                    value="{{ ev.linked_entity_id or '' if ev else '' }}">

--- a/src/templates/admin/shared/_event_form_row.html
+++ b/src/templates/admin/shared/_event_form_row.html
@@ -103,21 +103,25 @@
             </select>
           </div>
           <div class="form-group" style="margin-bottom:0;flex:1;position:relative">
-            <input type="text" autocomplete="off" placeholder="Search by name…"
-                   aria-label="Search for a linked entity"
-                   id="linked-entity-search-{{ _le_key }}"
-                   value="{{ linked_entity_label or (ev.linked_entity_id if ev else '') or '' }}"
-                   hx-get="/admin/entities/search/"
-                   hx-trigger="input changed delay:200ms"
-                   hx-target="#linked-entity-results-{{ _le_key }}"
-                   hx-swap="innerHTML"
-                   hx-include="#linked-entity-type-{{ _le_key }}"
-                   name="q"
-                   role="combobox"
-                   aria-expanded="false"
-                   aria-haspopup="listbox"
-                   aria-controls="linked-entity-results-{{ _le_key }}"
-                   aria-autocomplete="list">
+            <div class="typeahead-input-wrap">
+              <input type="text" autocomplete="off" placeholder="Search by name…"
+                     aria-label="Search for a linked entity"
+                     id="linked-entity-search-{{ _le_key }}"
+                     value="{{ linked_entity_label or (ev.linked_entity_id if ev else '') or '' }}"
+                     hx-get="/admin/entities/search/"
+                     hx-trigger="input changed delay:200ms"
+                     hx-target="#linked-entity-results-{{ _le_key }}"
+                     hx-swap="innerHTML"
+                     hx-include="#linked-entity-type-{{ _le_key }}"
+                     name="q"
+                     role="combobox"
+                     aria-expanded="false"
+                     aria-haspopup="listbox"
+                     aria-controls="linked-entity-results-{{ _le_key }}"
+                     aria-autocomplete="list">
+              <button type="button" class="typeahead-clear" id="linked-entity-clear-{{ _le_key }}"
+                      data-typeahead-clear aria-label="Clear linked entity">&times;</button>
+            </div>
             <input type="hidden" name="linked_entity_id" id="linked-entity-id-{{ _le_key }}"
                    value="{{ ev.linked_entity_id or '' if ev else '' }}">
             <ul id="linked-entity-results-{{ _le_key }}" class="typeahead-results" role="listbox"></ul>

--- a/tests/api/admin/test_roles.py
+++ b/tests/api/admin/test_roles.py
@@ -627,6 +627,37 @@ async def test_structural_inline_edit_form_renders(client, structural_role):
     assert 'name="qualifier"' in r.text
 
 
+async def test_structural_inline_edit_form_has_jurisdiction_clear(client, structural_role):
+    """#358: jurisdiction picker exposes a "×" clear button wired to the factory."""
+    r = await client.get(
+        f"/admin/roles/{structural_role['role_id']}/inline/structural/edit/", headers=AUTH_HEADERS
+    )
+    assert r.status_code == 200
+    assert 'id="structural-jurisdiction-clear"' in r.text
+    assert "data-typeahead-clear" in r.text
+    assert "clearButtonId: 'structural-jurisdiction-clear'" in r.text
+
+
+async def test_structural_inline_clears_jurisdiction_keeping_role_type(client, db, structural_role):
+    """#358: an empty jurisdiction_id nulls the jurisdiction while the role type stays."""
+    r = await client.post(
+        f"/admin/roles/{structural_role['role_id']}/inline/structural/",
+        data={
+            "role_type_id": structural_role["rt_id"],
+            "jurisdiction_id": "",
+            "qualifier": "",
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert r.status_code == 200
+    row = await db.fetchrow(
+        "SELECT role_type_id, jurisdiction_id FROM roles WHERE id=$1",
+        structural_role["role_id"],
+    )
+    assert row["jurisdiction_id"] is None
+    assert row["role_type_id"] == structural_role["rt_id"]
+
+
 async def test_structural_inline_update_qualifier_persists(client, db, structural_role):
     """Non-WA role: qualifier updates; unsynthesizable title left untouched."""
     r = await client.post(

--- a/tests/js/event-form-row.test.js
+++ b/tests/js/event-form-row.test.js
@@ -101,6 +101,7 @@ describe('event-form-row', () => {
       inputId: 'linked-entity-search-ev_abc',
       listboxId: 'linked-entity-results-ev_abc',
       hiddenId: 'linked-entity-id-ev_abc',
+      clearButtonId: 'linked-entity-clear-ev_abc',
     });
   });
 

--- a/tests/js/event-form-row.test.js
+++ b/tests/js/event-form-row.test.js
@@ -77,7 +77,16 @@ let initStub;
 let addSpy;
 
 beforeEach(() => {
-  initStub = vi.fn();
+  // Mimic the real factory's return handle: clear() empties the input + hidden
+  // fields it was wired to, so the scope-switch path (combo.clear()) is exercised.
+  initStub = vi.fn((opts) => ({
+    clear: () => {
+      const i = opts && document.getElementById(opts.inputId);
+      const h = opts && document.getElementById(opts.hiddenId);
+      if (i) i.value = '';
+      if (h) h.value = '';
+    },
+  }));
   window.initTypeaheadCombobox = initStub;
   addSpy = vi.spyOn(document, 'addEventListener');
 });

--- a/tests/js/person-name-row-typeahead.test.js
+++ b/tests/js/person-name-row-typeahead.test.js
@@ -98,16 +98,19 @@ describe('person-name-row-typeahead', () => {
       inputId: 'locale-search-display-nid_abc',
       listboxId: 'locale-search-results-nid_abc',
       hiddenId: 'locale-hidden-nid_abc',
+      clearButtonId: 'locale-clear-nid_abc',
     });
     expect(callArgs).toContainEqual({
       inputId: 'script-search-display-nid_abc',
       listboxId: 'script-search-results-nid_abc',
       hiddenId: 'script-hidden-nid_abc',
+      clearButtonId: 'script-clear-nid_abc',
     });
     expect(callArgs).toContainEqual({
       inputId: 'reading-of-display-nid_abc',
       listboxId: 'reading-of-results-nid_abc',
       hiddenId: 'reading-of-hidden-nid_abc',
+      clearButtonId: 'reading-of-clear-nid_abc',
     });
   });
 

--- a/tests/js/typeahead-combobox.test.js
+++ b/tests/js/typeahead-combobox.test.js
@@ -346,7 +346,7 @@ function setupClearable({ presetLabel = '', presetId = '', withButton = false, o
     </div>
   `;
   eval(scriptCode);
-  window.initTypeaheadCombobox({
+  return window.initTypeaheadCombobox({
     inputId: INPUT_ID,
     listboxId: LIST_ID,
     hiddenId: HIDDEN_ID,
@@ -476,5 +476,31 @@ describe('clear button visibility (#358 CR)', () => {
     setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', withButton: true });
     typeInto('');
     expect(clearBtn().style.display).toBe('none');
+  });
+});
+
+describe('exposed clear() handle (#358 CR)', () => {
+  it('returns a handle with a clear() method', () => {
+    const api = setupClearable();
+    expect(typeof api.clear).toBe('function');
+  });
+
+  it('clear() empties the input, hidden id, and hides the button', () => {
+    const api = setupClearable({
+      presetLabel: 'District 43',
+      presetId: 'jur-1',
+      withButton: true,
+    });
+    api.clear();
+    expect(inp().value).toBe('');
+    expect(hidden().value).toBe('');
+    expect(clearBtn().style.display).toBe('none');
+  });
+
+  it('clear() fires onClear when a selection existed', () => {
+    const onClear = vi.fn();
+    const api = setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', onClear });
+    api.clear();
+    expect(onClear).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/js/typeahead-combobox.test.js
+++ b/tests/js/typeahead-combobox.test.js
@@ -318,3 +318,132 @@ describe('onSelect callback', () => {
     ).not.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Clearing the selection (#358)
+//
+// The hidden id was only ever *set* on selection, never cleared when the visible
+// text was emptied or edited away from the chosen label — so blanking the search
+// box silently re-submitted the previous id.  Two clear paths now exist:
+//   1. Blank-/edit-to-clear: any input that diverges from the selected label
+//      invalidates the hidden id.
+//   2. An optional visible "×" clear button (clearButtonId).
+// Both fire an optional onClear callback so dependent UI (e.g. relationship
+// phrase preview) can react.
+// ---------------------------------------------------------------------------
+
+/** Mount the factory with optional clear button + preset values + onClear. */
+function setupClearable({ presetLabel = '', presetId = '', withButton = false, onClear } = {}) {
+  document.body.innerHTML = `
+    <div style="position:relative">
+      <input id="${INPUT_ID}" type="text" autocomplete="off"
+             role="combobox" aria-expanded="false"
+             aria-haspopup="listbox" aria-controls="${LIST_ID}" aria-autocomplete="list"
+             value="${presetLabel}">
+      <input type="hidden" id="${HIDDEN_ID}" value="${presetId}">
+      ${withButton ? `<button type="button" id="test-clear" data-typeahead-clear aria-label="Clear">×</button>` : ''}
+      <ul id="${LIST_ID}" class="typeahead-results" role="listbox" style="display:none"></ul>
+    </div>
+  `;
+  eval(scriptCode);
+  window.initTypeaheadCombobox({
+    inputId: INPUT_ID,
+    listboxId: LIST_ID,
+    hiddenId: HIDDEN_ID,
+    ...(withButton ? { clearButtonId: 'test-clear' } : {}),
+    ...(onClear ? { onClear } : {}),
+  });
+}
+
+function clearBtn() {
+  return document.getElementById('test-clear');
+}
+
+/** Fire a realistic edit: set the value then dispatch an 'input' event. */
+function typeInto(value) {
+  inp().value = value;
+  inp().dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('blank-/edit-to-clear', () => {
+  it('clears the hidden id when the input is emptied after a selection', () => {
+    setupClearable();
+    populateResults([{ id: 'jur-1', label: 'District 43' }]);
+    getItems()[0].dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    expect(hidden().value).toBe('jur-1');
+    typeInto('');
+    expect(hidden().value).toBe('');
+  });
+
+  it('clears the hidden id when the text is edited away from the selected label', () => {
+    setupClearable();
+    populateResults([{ id: 'jur-1', label: 'District 43' }]);
+    getItems()[0].dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    typeInto('District 4');
+    expect(hidden().value).toBe('');
+  });
+
+  it('invalidates a server-rendered selection once its text is edited', () => {
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1' });
+    expect(hidden().value).toBe('jur-1');
+    typeInto('District 4');
+    expect(hidden().value).toBe('');
+  });
+
+  it('keeps the hidden id while the text still matches the selected label', () => {
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1' });
+    // An input event that does not change the text (matches label) must not clear.
+    typeInto('District 43');
+    expect(hidden().value).toBe('jur-1');
+  });
+
+  it('fires onClear once when a selection is invalidated by editing', () => {
+    const onClear = vi.fn();
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', onClear });
+    typeInto('District');
+    typeInto('Distric');
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onClear when the hidden id was already empty', () => {
+    const onClear = vi.fn();
+    setupClearable({ onClear });
+    typeInto('typing without selecting');
+    typeInto('');
+    expect(onClear).not.toHaveBeenCalled();
+  });
+});
+
+describe('clear button', () => {
+  it('clears both the input and hidden id on click', () => {
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', withButton: true });
+    clearBtn().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(inp().value).toBe('');
+    expect(hidden().value).toBe('');
+  });
+
+  it('refocuses the input after clearing', () => {
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', withButton: true });
+    clearBtn().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(document.activeElement).toBe(inp());
+  });
+
+  it('closes the dropdown on clear', () => {
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', withButton: true });
+    populateResults([{ id: 'jur-2', label: 'District 44' }]);
+    expect(ul().style.display).toBe('block');
+    clearBtn().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(ul().style.display).toBe('none');
+  });
+
+  it('fires onClear on clear-button click when something was selected', () => {
+    const onClear = vi.fn();
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', withButton: true, onClear });
+    clearBtn().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when clearButtonId is not provided', () => {
+    expect(() => setupClearable()).not.toThrow();
+  });
+});

--- a/tests/js/typeahead-combobox.test.js
+++ b/tests/js/typeahead-combobox.test.js
@@ -447,3 +447,34 @@ describe('clear button', () => {
     expect(() => setupClearable()).not.toThrow();
   });
 });
+
+describe('clear button visibility (#358 CR)', () => {
+  it('is hidden when no selection exists', () => {
+    setupClearable({ withButton: true });
+    expect(clearBtn().style.display).toBe('none');
+  });
+
+  it('is visible when a server-rendered selection is present', () => {
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', withButton: true });
+    expect(clearBtn().style.display).not.toBe('none');
+  });
+
+  it('appears after selecting an item', () => {
+    setupClearable({ withButton: true });
+    populateResults([{ id: 'jur-2', label: 'District 44' }]);
+    getItems()[0].dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    expect(clearBtn().style.display).not.toBe('none');
+  });
+
+  it('hides after clearing via the button', () => {
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', withButton: true });
+    clearBtn().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(clearBtn().style.display).toBe('none');
+  });
+
+  it('hides after blank-to-clear', () => {
+    setupClearable({ presetLabel: 'District 43', presetId: 'jur-1', withButton: true });
+    typeInto('');
+    expect(clearBtn().style.display).toBe('none');
+  });
+});

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.16.7"
+version = "0.16.8"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Closes #358.

## Problem
The shared `initTypeaheadCombobox` factory only ever **set** the paired hidden id (on select) and never cleared it. Blanking the visible search box left a stale ULID in the hidden field, so **Save silently re-submitted the previous selection** — and an optional FK accidentally set (the reported case: a role's jurisdiction) had no clear path short of setting Role type → "none", which demotes the role.

Server side already treated an empty FK as "clear" — this was purely a front-end gap, and it affected all 13 pickers that use the factory.

## Fix (factory-level, all pickers)
- **Stale-id guard** — the hidden id is valid only while the visible text equals the label of the last selection (seeded from the server-rendered value). Any diverging input (emptying or editing) clears it. This also kills the "I cleared it and it saved the old one" footgun on *required* pickers.
- **Visible "×" clear button** (`clearButtonId`) + **`onClear`** callback. `onClear` is used instead of `onSelect('')` so select-to-navigate consumers (the org merge-target picker) don't fire on a clear.

## Wiring
`×` added to the optional pickers: role jurisdiction (inline structural + new-role form), event linked-entity, and name-row locale/script/reading-of. `.typeahead-input-wrap` centres the button over the input. `STYLE.md §18` documents the new clear contract.

## Tests
- 7 new factory unit tests: blank-to-clear, edit-away-from-label invalidation, server-rendered invalidation, `onClear` fires once / not when already empty, clear-button (clears + refocus + closes dropdown + fires `onClear`).
- 2 new role endpoint tests: the × button renders wired to the factory; an empty `jurisdiction_id` nulls the jurisdiction while the role type stays.
- Existing exact-arg assertions in `event-form-row` / `person-name-row-typeahead` updated for `clearButtonId`.

Verified live on the dev server against the reported role — the structural edit form renders the × and the updated JS/CSS are served.

## Notes
- Full JS suite (311) green; ESLint + Prettier clean; role + people-names + events + a11y-render py suites green.
- 18 pre-existing `…/citations/…` a11y-render failures on `main` are unrelated (`KeyError: 'citation_id'` in the test harness param-map) and outside this diff.
- Version bumped to 0.16.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)