### PR TITLE
#360 chore: add .socraticodeignore to exclude vendored skill trees

### DIFF
--- a/.socraticodeignore
+++ b/.socraticodeignore
@@ -1,0 +1,6 @@
+# Exclude vendored skill trees from the semantic index (issue #360).
+# Layered on SocratiCode's built-in defaults + .gitignore.
+# skills/ itself is kept: it holds the first-party `brainstorming` skill.
+# Its other entries are symlinks that resolve into the excluded skills-vendor/ tree.
+skills-vendor/
+.claude/skills/


### PR DESCRIPTION
Closes #360.

## What

Adds `.socraticodeignore` at the repo root so SocratiCode stops indexing vendored skill trees as project code.

```gitignore
skills-vendor/
.claude/skills/
```

## Why

SocratiCode indexed `skills-vendor/` (git submodules) and `.claude/skills/` (symlink farm) as if they were project code — inflating embedding time and letting vendored skill content outrank this repo's own code in `codebase_search`.

## Scope note — `skills/` deliberately kept

This repo authors a first-party skill (`skills/brainstorming/SKILL.md`), so per the issue we exclude `skills-vendor/` and `.claude/skills/` only. `skills/`'s other entries are symlinks that resolve into the excluded `skills-vendor/` tree; `brainstorming` stays indexed.

No manifest change needed — `.socraticodecontextartifacts.json` already uses the singular `path` shape.

## Follow-up

Re-index the main checkout (`codebase_index`) after merge to realize the shrink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)