### PR TITLE
#363 fix: exit 3 on findings in assignment-relationship window audit

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -615,8 +615,10 @@ uv run "${env_args[@]}" python -m scripts.audit_assignment_relationship_windows 
 uv run "${env_args[@]}" python -m scripts.audit_assignment_relationship_windows --execute  # fix
 ```
 
-Idempotent. Intended as a daily timer (`power-map-assignment-rel-windows.timer`,
-install analogous to the ancillary-orphans timer — deploy-time infra step).
+Idempotent. Report mode **exits 3 when any drift is found** (0 when clean), so the
+daily `power-map-assignment-rel-windows.timer` shows as failed in `systemctl --failed`
+and can drive `OnFailure=` — same convention as the ancillary-orphans / schema-parity
+audits (#363). `--execute` reconciles the drift and always exits 0.
 
 ## Assignment-relationship backfill (issue #301)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.17.0"
+version = "0.17.1"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/audit_assignment_relationship_windows.py
+++ b/scripts/audit_assignment_relationship_windows.py
@@ -30,6 +30,7 @@ import argparse
 import asyncio
 import datetime
 import os
+import sys
 
 import asyncpg
 
@@ -140,7 +141,20 @@ def _log_report(findings: dict[str, list[dict]], *, execute: bool) -> None:
         logger.info("Pass --execute to apply")
 
 
-async def run(*, execute: bool) -> None:
+def _exit_code(findings: dict[str, list[dict]], *, execute: bool) -> int:
+    """Exit 3 when a report-only run found drift, else 0 (#363).
+
+    Mirrors the sibling audits (``audit_ancillary_orphans`` / ``audit_schema_constraint_parity``)
+    so the systemd unit shows as failed in ``systemctl --failed`` and can drive
+    ``OnFailure=``. ``--execute`` reconciled the drift, so it always exits 0.
+    """
+    if execute:
+        return 0
+    total = sum(len(rows) for rows in findings.values())
+    return 3 if total else 0
+
+
+async def run(*, execute: bool) -> int:
     dsn = os.environ.get("DATABASE_URL")
     if not dsn:
         raise RuntimeError("DATABASE_URL not set")
@@ -152,6 +166,7 @@ async def run(*, execute: bool) -> None:
         else:
             findings = await run_audit(conn, execute=False)
         _log_report(findings, execute=execute)
+        return _exit_code(findings, execute=execute)
     finally:
         await conn.close()
 
@@ -165,7 +180,7 @@ def main() -> None:
         help="Clamp/archive drifted edges (default is report-only)",
     )
     args = parser.parse_args()
-    asyncio.run(run(execute=args.execute))
+    sys.exit(asyncio.run(run(execute=args.execute)))
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_audit_assignment_relationship_windows.py
+++ b/tests/scripts/test_audit_assignment_relationship_windows.py
@@ -5,7 +5,14 @@ import datetime
 import pytest
 import pytest_asyncio
 
-from scripts.audit_assignment_relationship_windows import _clamp, audit, classify, run_audit
+from scripts.audit_assignment_relationship_windows import (
+    FINDING_CATEGORIES,
+    _clamp,
+    _exit_code,
+    audit,
+    classify,
+    run_audit,
+)
 from src.core.db import generate_id
 
 D = datetime.date
@@ -90,6 +97,36 @@ def test_classify_noop():
 
 
 # --------------------------------------------------------------------------- #
+# Exit code (#363) — report mode signals findings; execute reconciles → 0
+# --------------------------------------------------------------------------- #
+
+
+def _findings(**counts):
+    """Build a findings dict shaped like audit()'s return, with n blank rows/category."""
+    base = {c: [] for c in FINDING_CATEGORIES}
+    for cat, n in counts.items():
+        base[cat] = [{} for _ in range(n)]
+    return base
+
+
+def test_exit_code_report_clean_is_zero():
+    assert _exit_code(_findings(), execute=False) == 0
+
+
+def test_exit_code_report_with_findings_is_three():
+    assert _exit_code(_findings(clamp=2, inverted=1), execute=False) == 3
+
+
+def test_exit_code_execute_is_zero_even_with_findings():
+    # --execute reconciled the drift, so it exits 0 (mirrors issue #363).
+    assert _exit_code(_findings(archived_endpoint=3), execute=True) == 0
+
+
+def test_exit_code_execute_clean_is_zero():
+    assert _exit_code(_findings(), execute=True) == 0
+
+
+# --------------------------------------------------------------------------- #
 # DB reconcile
 # --------------------------------------------------------------------------- #
 
@@ -160,6 +197,16 @@ async def test_reconcile_clamps_and_is_idempotent(conn):
     # idempotent: a second pass finds nothing
     again = await audit(conn)
     assert sum(len(v) for v in again.values()) == 0
+
+
+@integration
+async def test_report_mode_real_drift_exits_three(conn):
+    # A real drifted edge → audit() findings → report-mode exit code 3 (#363).
+    frm = await _assignment(conn, start=D(2023, 1, 1))
+    to = await _assignment(conn, start=D(2023, 1, 1), end=D(2024, 12, 31))
+    await _edge(conn, frm, to, vf=D(2023, 1, 1), vu=D(2030, 1, 1))
+    findings = await audit(conn)  # report-only, no mutation
+    assert _exit_code(findings, execute=False) == 3
 
 
 @integration

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Closes #363. Follow-up from the #301 deploy.

## Problem
`scripts/audit_assignment_relationship_windows.py` ran report-only in the daily `power-map-assignment-rel-windows.timer` but never exited non-zero on findings, so the timer was silent-on-drift — unlike its sibling audits (`audit_ancillary_orphans`, `audit_schema_constraint_parity`) which exit 3 so the unit surfaces in `systemctl --failed` and can drive `OnFailure=`.

## Change
- `_exit_code(findings, *, execute)` — report mode returns **3** when any finding exists, **0** when clean; `--execute` reconciled the drift so it always returns 0.
- `run()` returns the code; `main()` `sys.exit()`s it.
- Doc note in `docs/COMMANDS.md`; version → 0.17.1.

## Tests
- 4 unit tests over the `_exit_code` matrix (report clean/dirty, execute clean/dirty).
- 1 integration test: a real drifted edge → `audit()` findings → report-mode exit code 3.
- Verified against clean prod: report mode exits 0.

## Deploy
No infra change — the unit files are unchanged; the timer's `WorkingDirectory` is the main checkout, so the updated script takes effect on `main` pull (no restart / daemon-reload needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)