### PR TITLE
#369 CR follow-ups: summary-only a11y surfacing + duplicate-safe dedup

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -221,7 +221,15 @@ Surfacing (two layers): the unit shows in `systemctl --failed` on any failure
 (the ambient signal the SessionStart hook `.claude/hooks/a11y-status-reminder.sh`
 reads and echoes when you open Claude on the VM); and on failure the runner
 opens-or-updates a single `a11y-regression` GitHub issue (closing it on the next
-green run — GitHub's notification email covers the "email me" need).
+green run — GitHub's notification email covers the "email me" need). The issue
+carries a **one-line summary + a pointer to the journal only** — never raw
+output, since this is a public repo. Full failing detail (axe violations,
+tracebacks) lives in `journalctl -u power-map-a11y` on the VM.
+
+To exercise the failure → open-issue → recover → close cycle without breaking a
+tier, run with the self-test hatch: `A11Y_SWEEP_FORCE_FAIL=1 bash
+scripts/run-a11y-sweep.sh` (opens a synthetic-failure issue), then a normal green
+run closes it. `A11Y_SWEEP_NO_GH=1` logs the GitHub actions instead of doing them.
 
 One-time VM setup (the guard fails until this is done):
 

--- a/scripts/run-a11y-sweep.sh
+++ b/scripts/run-a11y-sweep.sh
@@ -3,13 +3,19 @@
 #
 # Runs both accessibility tiers against the dedicated test DB and surfaces the
 # result for operator review:
-#   - lxml rendered-DOM tier   (tests/api/admin/test_a11y_render.py  -m integration, #246)
+#   - lxml rendered-DOM tier      (tests/api/admin/test_a11y_render.py  -m integration, #246)
 #   - Playwright/axe browser tier (tests/api/admin/test_a11y_browser.py -m browser,    #300)
 #
-# Surfacing (two layers, see docs/COMMANDS.md § Browser Testing):
+# Output: everything goes to stdout/stderr, which systemd captures to the journal
+# (`journalctl -u power-map-a11y`). The full failing detail (axe violations,
+# tracebacks) stays there, on the VM — it is NEVER posted to GitHub, because
+# CannObserv/power-map is a PUBLIC repo (#369 CR).
+#
+# Surfacing (two layers, see docs/COMMANDS.md § weekly a11y sweep timer):
 #   - Durable: on failure, open-or-update a single GitHub issue labelled
-#     `a11y-regression` (dedup → one issue, not spam); on recovery, comment + close
-#     it. GitHub's own notification emails cover the "email me" need — no MTA here.
+#     `a11y-regression` (dedup → one issue, not spam) carrying only a one-line
+#     summary + a pointer to the journal; on recovery, comment + close it.
+#     GitHub's own notification emails cover the "email me" need — no MTA here.
 #   - Ambient: `systemctl --failed` (this unit) drives the SessionStart hook note.
 #
 # Exit codes: 0 = both tiers green; 1 = a tier failed; 2 = environment guard
@@ -17,16 +23,16 @@
 # vacuously, which must fail loudly instead). systemd marks the unit failed on
 # any non-zero, so it shows in `systemctl --failed`.
 #
-# Testing: set A11Y_SWEEP_NO_GH=1 to log the GitHub actions instead of performing
-# them (used when exercising the runner outside the timer).
+# Test hatches:
+#   A11Y_SWEEP_NO_GH=1      log the GitHub actions instead of performing them.
+#   A11Y_SWEEP_FORCE_FAIL=1 skip guard+tiers and exercise the failure surfacing
+#                           (synthetic — for verifying the open/close cycle).
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 LABEL="a11y-regression"
-LOG="$(mktemp -t a11y-sweep.XXXXXX.log)"
-trap 'rm -f "$LOG"' EXIT
 
 log() { echo "[$(date -u +%FT%TZ)] $*"; }
 
@@ -35,15 +41,16 @@ env_args=()
 [ -f "$REPO_ROOT/.env" ] && env_args+=(--env-file "$REPO_ROOT/.env")
 
 # --- GitHub surfacing ------------------------------------------------------
-# $1 = "fail" | "pass". On fail: open-or-update the labelled issue with a log
-# tail. On pass: close any open one. Best-effort — never aborts the run.
+# gh_surface <fail|pass> [summary]
+# On fail: open-or-update the labelled issue with SUMMARY ONLY (never raw output
+# — public repo). On pass: close any open one. Best-effort — never aborts the run.
 gh_surface() {
-    local status="$1" ts host body existing
+    local status="$1" summary="${2:-}" ts host existing body
     ts="$(date -u +%FT%TZ)"
     host="$(hostname)"
 
     if [ -n "${A11Y_SWEEP_NO_GH:-}" ]; then
-        log "A11Y_SWEEP_NO_GH set — would surface status=$status to GitHub label '$LABEL'"
+        log "A11Y_SWEEP_NO_GH set — would surface status=$status (${summary:-n/a}) to label '$LABEL'"
         return 0
     fi
     if ! command -v gh >/dev/null 2>&1; then
@@ -60,8 +67,9 @@ gh_surface() {
     existing="$(gh issue list --label "$LABEL" --state open --json number -q '.[0].number' 2>/dev/null || true)"
 
     if [ "$status" = "fail" ]; then
-        body="$(printf '**Weekly a11y sweep FAILED** — %s (host \`%s\`)\n\nAutomated by `power-map-a11y.timer` (#369). Full run: `journalctl -u power-map-a11y`.\n\n```\n%s\n```' \
-            "$ts" "$host" "$(tail -n 60 "$LOG")")"
+        # Summary + journal pointer ONLY — no raw internals (public repo, #369 CR).
+        body="$(printf '**Weekly a11y sweep FAILED** — %s (host `%s`).\n\n%s\n\nFull output is on the VM: `journalctl -u power-map-a11y` (deliberately not published — this is a public repo). Automated by `power-map-a11y.timer` (#369).' \
+            "$ts" "$host" "${summary:-a11y sweep failed}")"
         if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body" >/dev/null && log "commented failure on #$existing"
         else
@@ -78,12 +86,21 @@ gh_surface() {
     fi
 }
 
+# --- Test hatch: exercise failure surfacing without breaking a tier ---------
+# Skips the guard + tiers and surfaces a synthetic failure, so the open/update →
+# recover/close cycle can be verified in seconds (#369 CR finding 3).
+if [ -n "${A11Y_SWEEP_FORCE_FAIL:-}" ]; then
+    log "A11Y_SWEEP_FORCE_FAIL set — exercising failure surfacing (synthetic, not a real regression)"
+    gh_surface fail "synthetic failure (A11Y_SWEEP_FORCE_FAIL) — surfacing self-test, ignore."
+    exit 1
+fi
+
 # --- Guard: Chromium must actually launch --------------------------------
 # The browser tier importorskips when Playwright/Chromium is absent, which would
 # report "skipped" (exit 0) and pass vacuously. Launch a real browser here so a
 # missing install fails the run loudly (#369).
 log "verifying Playwright Chromium is installed"
-if ! uv run --group browser "${env_args[@]}" python - <<'PY' >>"$LOG" 2>&1; then
+if ! uv run --group browser "${env_args[@]}" python - <<'PY'; then
 from playwright.sync_api import sync_playwright
 
 with sync_playwright() as p:
@@ -92,18 +109,19 @@ with sync_playwright() as p:
 print("chromium OK")
 PY
     log "FATAL: Playwright Chromium unavailable — run: uv run --group browser playwright install chromium"
-    gh_surface fail
+    gh_surface fail "Chromium guard failed — Playwright browser unavailable on the VM."
     exit 2
 fi
 
 # --- Run both tiers (separate pytest sessions: distinct DB-isolation models) ---
+# Output streams to stdout → journald; nothing is buffered to a file.
 run_tier() {
     local name="$1"
     shift
-    echo "===== ${name} =====" | tee -a "$LOG"
-    uv run --group browser "${env_args[@]}" pytest "$@" >>"$LOG" 2>&1
+    echo "===== ${name} ====="
+    uv run --group browser "${env_args[@]}" pytest "$@"
     local rc=$?
-    echo "${name} exit: ${rc}" | tee -a "$LOG"
+    echo "${name} exit: ${rc}"
     return "$rc"
 }
 
@@ -121,7 +139,7 @@ overall=0
 
 if [ "$overall" -ne 0 ]; then
     log "a11y sweep FAILED (lxml=$lxml_rc browser=$browser_rc)"
-    gh_surface fail
+    gh_surface fail "a11y tiers failed — lxml exit ${lxml_rc}, browser exit ${browser_rc}. See the journal for the failing assertions."
 else
     log "a11y sweep GREEN (lxml=$lxml_rc browser=$browser_rc)"
     gh_surface pass

--- a/scripts/run-a11y-sweep.sh
+++ b/scripts/run-a11y-sweep.sh
@@ -45,7 +45,7 @@ env_args=()
 # On fail: open-or-update the labelled issue with SUMMARY ONLY (never raw output
 # — public repo). On pass: close any open one. Best-effort — never aborts the run.
 gh_surface() {
-    local status="$1" summary="${2:-}" ts host existing body
+    local status="$1" summary="${2:-}" ts host existing body list_rc
     ts="$(date -u +%FT%TZ)"
     host="$(hostname)"
 
@@ -64,7 +64,16 @@ gh_surface() {
             --description "Automated weekly a11y sweep regression (power-map-a11y.timer, #369)" \
             2>/dev/null || true
     fi
-    existing="$(gh issue list --label "$LABEL" --state open --json number -q '.[0].number' 2>/dev/null || true)"
+    # Distinguish a genuine "no open issue" (list ok, empty result) from a
+    # transient gh failure — on error, skip surfacing this run rather than risk
+    # opening a duplicate or closing nothing (#369 CR2 finding 5).
+    existing="$(gh issue list --label "$LABEL" --state open --json number -q '.[0].number' 2>/dev/null)"
+    list_rc=$?
+    [ "$existing" = "null" ] && existing=""
+    if [ "$list_rc" -ne 0 ]; then
+        log "gh issue list failed (rc=$list_rc) — skipping surfacing this run to avoid a duplicate"
+        return 0
+    fi
 
     if [ "$status" = "fail" ]; then
         # Summary + journal pointer ONLY — no raw internals (public repo, #369 CR).


### PR DESCRIPTION
Code-review follow-ups on the #369 weekly a11y timer (3 CR rounds). No behavior change to the sweep itself — only how failures are surfaced.

## Fixes
- **CR1 (security, top finding):** `CannObserv/power-map` is a **public** repo and the failure path posted a raw 60-line log tail into a GitHub issue. Now the issue carries a **one-line summary + a `journalctl -u power-map-a11y` pointer only**; tier output streams to stdout→journald so the full failing detail stays on the VM. (`fc188ea`)
- **CR2 (cleanup):** dropped the temp file entirely, which also removed the trap that wouldn't have fired on a SIGTERM timeout. (`fc188ea`)
- **CR3 (confirmation):** added a guarded `A11Y_SWEEP_FORCE_FAIL` self-test hatch; verified the full open→recover→close cycle live (issues #372, #374 opened summary-only then auto-closed by a green run). (`fc188ea`)
- **CR2 finding 5 (harden):** `gh issue list` transient error no longer collapses into "no open issue" → won't open a duplicate; on a hard error it skips surfacing (the failure still shows in `systemctl --failed` + the SessionStart hook). (`817cbce`)

## Verification
- Full open→close cycle exercised twice against real GitHub (summary-only bodies confirmed).
- `A11Y_SWEEP_NO_GH=1` green run: both tiers pass, detail streams to the journal.
- Pre-ship green: ruff + format clean, unit suite + vitest pass. No Python touched.

## Follow-up filed
- **#373** — automated (bats) test coverage for the a11y-sweep bash scripts + optional shellcheck pre-commit hook.

## Deploy
Reaches prod via a plain `git pull` on `main` — the `power-map-a11y.service` unit already points at the checked-out script; no unit re-copy or `daemon-reload` needed.

Refs: #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)