### PR TITLE
#379 fix: strip consumed ?flash= param from URL after hard-nav redirects

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -327,6 +327,10 @@ HTMX dispatches a `showFlash` DOM event when it processes the `HX-Trigger` respo
 
 **Timing:** `HX-Trigger` fires immediately on response receipt, before the DOM swap. This is imperceptible for fixed-position flash overlays. If a future route needs to reference post-swap DOM state, use `HX-Trigger-After-Settle` as the header name instead.
 
+**Query-param flash (`?flash=<key>`) — the redirect-landing variant.** A redirect that ends on a full page (the Danger-Zone delete → list `HX-Redirect` navigation, #376; a non-HTMX 303 fallback, #351) can't carry an `HX-Trigger`, so it passes a `?flash=<key>` query param that the target route resolves via `resolve_query_flash` and renders server-side into `{% block flash %}`. Two mechanisms then clear the now-consumed param from the address bar so a manual refresh won't re-show the message:
+- **Boosted navigations** — `resolve_query_flash` returns an `HX-Replace-Url` header (on non-HTMX requests) that htmx honors while processing the boosted response.
+- **Hard navigations** — `HX-Replace-Url` is inert when htmx isn't driving the request (`window.location` from `HX-Redirect`, a plain 303→GET). `flash.js` covers this: on every full page load it strips a `flash` param via `history.replaceState`, preserving other params (#379). The two are complementary — keep both.
+
 ### Mutation form pattern
 
 ```html

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.18.1"
+version = "0.18.2"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/static/admin/flash.js
+++ b/src/static/admin/flash.js
@@ -19,12 +19,8 @@
     var url = new URL(window.location.href);
     if (!url.searchParams.has('flash')) return;
     url.searchParams.delete('flash');
-    var qs = url.searchParams.toString();
-    window.history.replaceState(
-      window.history.state,
-      '',
-      url.pathname + (qs ? '?' + qs : '') + url.hash,
-    );
+    // url.search is '' when no params remain, so this handles both cases.
+    window.history.replaceState(window.history.state, '', url.pathname + url.search + url.hash);
   } catch {
     /* no-op: URL / history API unavailable */
   }

--- a/src/static/admin/flash.js
+++ b/src/static/admin/flash.js
@@ -4,6 +4,32 @@
  * HX-Trigger response header containing {"showFlash": {"level": "...", "body": "..."}}.
  * This listener catches that event and injects a flash notification into #flash-region.
  */
+
+/* Strip a consumed ?flash= param from the URL on load (#379).
+ *
+ * A full-page navigation that lands on a flash-bearing URL — the HX-Redirect
+ * delete→list landing (#376) or a non-HTMX 303 fallback — leaves ?flash=<key>
+ * in the address bar. The flash is already server-rendered into #flash-region,
+ * so removing the param here only stops a manual refresh from re-showing it.
+ * Boosted navigations are handled server-side by HX-Replace-Url (htmx honors
+ * that header only on htmx-initiated requests), so this covers the hard-nav gap.
+ */
+(function () {
+  try {
+    var url = new URL(window.location.href);
+    if (!url.searchParams.has('flash')) return;
+    url.searchParams.delete('flash');
+    var qs = url.searchParams.toString();
+    window.history.replaceState(
+      window.history.state,
+      '',
+      url.pathname + (qs ? '?' + qs : '') + url.hash,
+    );
+  } catch {
+    /* no-op: URL / history API unavailable */
+  }
+})();
+
 (function () {
   var AUTO_DISMISS_MS = 4000;
 

--- a/tests/js/flash-url-strip.test.js
+++ b/tests/js/flash-url-strip.test.js
@@ -1,0 +1,60 @@
+/**
+ * Tests for the ?flash= URL-strip IIFE in src/static/admin/flash.js (#379).
+ *
+ * A full-page navigation that lands on a flash-bearing URL (HX-Redirect
+ * delete→list from #376, or a non-HTMX 303 fallback) leaves ?flash=<key> in the
+ * address bar. The server-rendered flash is already in #flash-region, so on load
+ * flash.js strips the consumed param via history.replaceState — a manual refresh
+ * then won't re-show the message. Boosted navigations are handled server-side by
+ * HX-Replace-Url and are out of scope here.
+ *
+ * Pattern: set window URL → eval() the IIFE (runs on load) → assert the URL.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const scriptCode = readFileSync(resolve(__dirname, '../../src/static/admin/flash.js'), 'utf-8');
+
+function setUrl(url) {
+  // happy-dom: authoritative way to (re)point window.location without a real nav.
+  window.happyDOM.setURL(url);
+}
+
+describe('flash.js — ?flash= URL strip on load', () => {
+  beforeEach(() => {
+    setUrl('http://localhost/admin/');
+  });
+
+  it('removes a lone ?flash= param, preserving the path', () => {
+    setUrl('http://localhost/admin/orgs/?flash=deleted');
+    eval(scriptCode);
+    expect(window.location.pathname).toBe('/admin/orgs/');
+    expect(window.location.search).toBe('');
+  });
+
+  it('removes only flash, keeping other query params', () => {
+    setUrl('http://localhost/admin/role-assignments/?status=all&flash=deleted&q=foo');
+    eval(scriptCode);
+    const params = new URLSearchParams(window.location.search);
+    expect(params.has('flash')).toBe(false);
+    expect(params.get('status')).toBe('all');
+    expect(params.get('q')).toBe('foo');
+  });
+
+  it('leaves a URL without a flash param untouched', () => {
+    setUrl('http://localhost/admin/people/?status=active');
+    eval(scriptCode);
+    expect(window.location.pathname).toBe('/admin/people/');
+    expect(window.location.search).toBe('?status=active');
+  });
+
+  it('preserves the hash fragment while stripping flash', () => {
+    setUrl('http://localhost/admin/orgs/?flash=deleted#section');
+    eval(scriptCode);
+    expect(window.location.search).toBe('');
+    expect(window.location.hash).toBe('#section');
+  });
+});

--- a/tests/js/flash-url-strip.test.js
+++ b/tests/js/flash-url-strip.test.js
@@ -13,19 +13,33 @@
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const scriptCode = readFileSync(resolve(__dirname, '../../src/static/admin/flash.js'), 'utf-8');
 
 function setUrl(url) {
   // happy-dom: authoritative way to (re)point window.location without a real nav.
+  if (!window.happyDOM) throw new Error('these tests require the happy-dom vitest environment');
   window.happyDOM.setURL(url);
 }
 
 describe('flash.js — ?flash= URL strip on load', () => {
+  // eval()-ing flash.js registers a document 'showFlash' listener each run;
+  // spy on addEventListener and remove them in afterEach so they don't
+  // accumulate across tests (same guard as dark-mode.test.js).
+  let addSpy;
+
   beforeEach(() => {
+    addSpy = vi.spyOn(document, 'addEventListener');
     setUrl('http://localhost/admin/');
+  });
+
+  afterEach(() => {
+    for (const [type, fn] of addSpy.mock.calls) {
+      document.removeEventListener(type, fn);
+    }
+    addSpy.mockRestore();
   });
 
   it('removes a lone ?flash= param, preserving the path', () => {

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Closes #379.

## Problem
A redirect that ends in a **hard browser navigation** and lands on a flash-bearing URL — the Danger-Zone delete → list `HX-Redirect` (#376), or a non-HTMX 303 fallback (#351) — left `?flash=<key>` in the address bar. A manual refresh then re-showed the flash.

`resolve_query_flash` already emits an `HX-Replace-Url` header to strip the param, but htmx honors that header **only while processing an htmx-initiated request** — i.e. **boosted** navigations (the layout is `hx-boost="true"`). On a hard `window.location` navigation it is inert, so the param survives.

## Fix
`flash.js` now strips a consumed `flash` param via `history.replaceState` on every full page load, preserving all other query params (`status`, `q`, hash, …). The flash is already server-rendered into `#flash-region`, so this only affects the URL bar — a refresh no longer re-triggers it.

The two mechanisms are **complementary and both kept**:
- Boosted navigations → server `HX-Replace-Url` (unchanged, still tested)
- Hard navigations → client-side strip in `flash.js` (new)

Uniform across every entity — no per-route special-casing.

## Tests (TDD)
New `tests/js/flash-url-strip.test.js` (vitest + happy-dom): lone param stripped, other params preserved, no-flash URL untouched, hash preserved. Red → Green confirmed. Full JS suite 323 green; eslint + prettier clean.

## Docs
STYLE.md §32 documents the query-param flash variant and the two complementary URL-clearing mechanisms.

Version 0.18.1 → 0.18.2. Static-asset change; cache-bust is automatic (`asset_version` = git short SHA, changes on deploy restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)