### PR TITLE
#378 fix: unify uvicorn access/error logs via --log-config JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ exe.dev proxy: dev server at `https://power-map.exe.xyz:8001/`.
 |---|---|
 | After code change (production) | `sudo systemctl restart power-map` — also applies any schema changes |
 | After schema change only (no restart) | `bash scripts/apply-schema.sh` |
-| Worktree dev testing | kill+restart dev server on 8001 with `--reload` from worktree dir |
+| Worktree dev testing | kill+restart dev server on 8001 with `--reload --log-config src/core/log_config.json` from worktree dir (see README / `docs/COMMANDS.md` for the full command) |
 | Service debugging | `sudo journalctl -u power-map -f` |
 | Quick prod health check | `curl -fsS localhost:8000/health && curl -fsS localhost:8000/ready` — unauthenticated probes (#343); `/ready` 503 reason: `no_pool`/`pool_timeout`/`db_error` |
 | Outbox/tombstone TTL prune | daily `power-map-prune.timer` runs `scripts/prune_outbox.py --execute` (90-day window, `entity_changes` + `deleted_entities`); see `docs/COMMANDS.md` |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ uv sync
 ## Development
 
 ```bash
-uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8001 --reload
+uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8001 --reload --log-config src/core/log_config.json
 ```
 
 ## Testing

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -150,7 +150,7 @@ env_args=()
 
 # Kill any existing dev server on 8001, then start fresh from your worktree
 fuser -k 8001/tcp 2>/dev/null; sleep 1
-uv run "${env_args[@]}" uvicorn src.api.main:app --host 0.0.0.0 --port 8001 --reload
+uv run "${env_args[@]}" uvicorn src.api.main:app --host 0.0.0.0 --port 8001 --reload --log-config src/core/log_config.json
 
 # Inject admin auth headers locally via mitmdump reverse proxy (port 3000 → 8001)
 mitmdump \

--- a/infra/power-map.service
+++ b/infra/power-map.service
@@ -11,7 +11,7 @@ EnvironmentFile=-/home/exedev/power-map/.env
 # Requires uv on PATH (/usr/local/bin/uv); verify: systemctl show power-map --property=Environment
 ExecStartPre=uv sync --quiet
 ExecStartPre=bash scripts/apply-schema.sh
-ExecStart=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8000 --workers 2
+ExecStart=uv run uvicorn src.api.main:app --host 0.0.0.0 --port 8000 --workers 2 --log-config src/core/log_config.json
 Restart=on-failure
 RestartSec=5s
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.18.2"
+version = "0.18.3"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/core/log_config.json
+++ b/src/core/log_config.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "json": { "()": "src.core.logging.build_json_formatter" }
+  },
+  "handlers": {
+    "stdout": {
+      "class": "logging.StreamHandler",
+      "formatter": "json",
+      "stream": "ext://sys.stdout"
+    }
+  },
+  "root": { "level": "INFO", "handlers": ["stdout"] },
+  "loggers": {
+    "uvicorn": { "level": "INFO", "handlers": ["stdout"], "propagate": false },
+    "uvicorn.error": { "level": "INFO", "handlers": ["stdout"], "propagate": false },
+    "uvicorn.access": { "level": "INFO", "handlers": ["stdout"], "propagate": false }
+  }
+}

--- a/src/core/logging.py
+++ b/src/core/logging.py
@@ -6,18 +6,36 @@ import sys
 from pythonjsonlogger.json import JsonFormatter
 
 
-def configure_logging(level: int = logging.INFO) -> None:
-    """Configure root logger with JSON formatting. Call once at entry points."""
-    handler = logging.StreamHandler(sys.stdout)
-    # Keys must be named in fmt: a bare JsonFormatter() defaults to
-    # "%(message)s" and emits records with no level, logger, or timestamp.
-    handler.setFormatter(
-        JsonFormatter(
-            "%(levelname)s %(name)s %(message)s",
-            timestamp=True,
-            rename_fields={"levelname": "level", "name": "logger"},
-        )
+def build_json_formatter() -> JsonFormatter:
+    """The single JSON formatter definition for the whole process.
+
+    Referenced by BOTH ``configure_logging()`` (non-uvicorn entry points) and
+    ``src/core/log_config.json`` (uvicorn's ``--log-config``, via the dictConfig
+    ``"()"`` factory key), so app records and uvicorn's own access/error lines
+    serialize with one identical schema — no drift, one place to change.
+
+    Keys must be named in the fmt: a bare ``JsonFormatter()`` defaults to
+    ``"%(message)s"`` and emits records with no level, logger, or timestamp
+    (skills#69).
+    """
+    return JsonFormatter(
+        "%(levelname)s %(name)s %(message)s",
+        timestamp=True,
+        rename_fields={"levelname": "level", "name": "logger"},
     )
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure the root logger with JSON formatting. Call once at entry
+    points that do NOT run under uvicorn (CLI scripts, cron oneshots, tests).
+
+    Under uvicorn, ``--log-config src/core/log_config.json`` configures the
+    whole logging tree at boot instead; this call is then a harmless reinstall
+    of an identical root handler, which keeps app logs JSON even if someone
+    launches uvicorn without ``--log-config``.
+    """
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(build_json_formatter())
     root = logging.getLogger()
     root.setLevel(level)
     root.handlers = [handler]

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -1,9 +1,15 @@
-"""Regression test: JSON log records carry timestamp, level, and logger name."""
+"""Regression tests: JSON log records carry timestamp, level, and logger name,
+and uvicorn's own loggers share the app's JSON formatter (skills#69, skills#81).
+"""
 
 import json
 import logging
+import logging.config
+from pathlib import Path
 
-from src.core.logging import configure_logging, get_logger
+from src.core.logging import build_json_formatter, configure_logging, get_logger
+
+LOG_CONFIG_PATH = Path("src/core/log_config.json")
 
 
 def test_log_record_includes_structured_fields(capsys):
@@ -20,3 +26,57 @@ def test_log_record_includes_structured_fields(capsys):
     assert record["level"] == "WARNING"
     assert record["logger"] == "src.some.module"
     assert "timestamp" in record
+
+
+def test_uvicorn_log_config_is_valid_and_shares_formatter():
+    """The uvicorn --log-config file wires uvicorn's loggers through the same
+    formatter as the app, and dictConfig accepts it (a malformed file would
+    fail the service at boot, not in review)."""
+    config = json.loads(LOG_CONFIG_PATH.read_text())
+
+    # Single source of truth: the file builds its formatter from the factory
+    # configure_logging() also uses, not a duplicated fmt string.
+    assert any(
+        f.get("()") == "src.core.logging.build_json_formatter"
+        for f in config["formatters"].values()
+    )
+    # All three uvicorn loggers must be present, else they keep the plain default.
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        assert name in config["loggers"]
+
+    names = ("", "uvicorn", "uvicorn.error", "uvicorn.access")
+    saved = {
+        n: (
+            logging.getLogger(n).handlers[:],
+            logging.getLogger(n).propagate,
+            logging.getLogger(n).level,
+        )
+        for n in names
+    }
+    try:
+        logging.config.dictConfig(config)  # raises on a malformed config
+    finally:
+        # Restore level too: dictConfig sets root + uvicorn loggers to INFO,
+        # and leaking that into later tests would be an order-dependent flake.
+        for n, (handlers, propagate, level) in saved.items():
+            lg = logging.getLogger(n)
+            lg.handlers, lg.propagate, lg.level = handlers, propagate, level
+
+
+def test_shared_formatter_renders_uvicorn_access_record():
+    """A uvicorn.access record formats to JSON with the same fields as app logs
+    — the request line lands in `message`, not a plain-text handler."""
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:0", "GET", "/health", "1.1", 200),
+        exc_info=None,
+    )
+    parsed = json.loads(build_json_formatter().format(record))
+    assert parsed["logger"] == "uvicorn.access"
+    assert parsed["level"] == "INFO"
+    assert parsed["message"] == '127.0.0.1:0 - "GET /health HTTP/1.1" 200'
+    assert "timestamp" in parsed

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.18.2"
+version = "0.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary

Backport of gregoryfoster/skills#81. uvicorn's own loggers (`uvicorn`, `uvicorn.access`, `uvicorn.error`) ship with `propagate=False` and their own **plain-text** handlers. The app configured only the **root** logger for JSON (`src/core/logging.py`), which uvicorn's loggers never reach — so journald got **mixed-format** logs: plain-text access/error lines interleaved with JSON app records.

## Changes

- **`build_json_formatter()`** extracted in `src/core/logging.py` as the single formatter source of truth, referenced by both `configure_logging()` and the new log-config file.
- **`src/core/log_config.json`** — uvicorn dictConfig that routes `uvicorn`/`uvicorn.access`/`uvicorn.error` (+ `root`) through that same formatter via the `"()"` factory key (`propagate: false`, single stdout handler). No duplicated fmt string.
- **`--log-config src/core/log_config.json`** wired into the systemd `ExecStart` (`infra/power-map.service`) and every dev-server command (README, `docs/COMMANDS.md`). `--workers 2` is fine — each worker loads the config independently.
- **Tests** (`tests/core/test_logging.py`): pin that the log-config stays valid under `dictConfig`, single-sources the formatter, and that a `uvicorn.access` record renders to JSON with `{level, logger, message, timestamp}`.

## Verify

End-to-end boot with `--log-config` confirmed — every uvicorn line (boot, access, lifecycle) + app logs emit as one JSON schema:

```
{"level": "INFO", "logger": "uvicorn.error", "message": "Application startup complete.", ...}
{"level": "INFO", "logger": "uvicorn.access", "message": "127.0.0.1:38150 - \"GET /health HTTP/1.1\" 200", ...}
```

`uv run pytest tests/core/test_logging.py` → 3 passed. Version 0.18.2 → 0.18.3.

Closes #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)