### PR TITLE
#383 fix: strip uvicorn color_message extra from JSON logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.18.3"
+version = "0.18.4"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/core/log_config.json
+++ b/src/core/log_config.json
@@ -4,6 +4,9 @@
   "formatters": {
     "json": { "()": "src.core.logging.build_json_formatter" }
   },
+  "filters": {
+    "strip_color_message": { "()": "src.core.logging.ColorMessageFilter" }
+  },
   "handlers": {
     "stdout": {
       "class": "logging.StreamHandler",
@@ -13,8 +16,8 @@
   },
   "root": { "level": "INFO", "handlers": ["stdout"] },
   "loggers": {
-    "uvicorn": { "level": "INFO", "handlers": ["stdout"], "propagate": false },
-    "uvicorn.error": { "level": "INFO", "handlers": ["stdout"], "propagate": false },
-    "uvicorn.access": { "level": "INFO", "handlers": ["stdout"], "propagate": false }
+    "uvicorn": { "level": "INFO", "handlers": ["stdout"], "filters": ["strip_color_message"], "propagate": false },
+    "uvicorn.error": { "level": "INFO", "handlers": ["stdout"], "filters": ["strip_color_message"], "propagate": false },
+    "uvicorn.access": { "level": "INFO", "handlers": ["stdout"], "filters": ["strip_color_message"], "propagate": false }
   }
 }

--- a/src/core/logging.py
+++ b/src/core/logging.py
@@ -25,6 +25,27 @@ def build_json_formatter() -> JsonFormatter:
     )
 
 
+class ColorMessageFilter(logging.Filter):
+    """Drop uvicorn's ``color_message`` extra before anything serializes it.
+
+    uvicorn logs its lifecycle lines (``server.py``, ``config.py``, the
+    ``--reload`` supervisors) with an ANSI-coloured duplicate attached as
+    ``extra={"color_message": ...}`` for its own colour-aware formatter. Every
+    extra reaches the JSON payload, so each ``uvicorn.error`` record otherwise
+    carries a second copy of its message with raw ANSI escapes.
+
+    Placed on the uvicorn loggers (not the stdout handler) so the strip happens
+    once at the record's source, before any handler reads it — a handler that
+    builds its payload from ``record.__dict__`` (e.g. OpenTelemetry's
+    ``LoggingHandler``) would otherwise resurrect the field (skills#82, #383).
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Strip the extra if present. Never drops a record."""
+        record.__dict__.pop("color_message", None)
+        return True
+
+
 def configure_logging(level: int = logging.INFO) -> None:
     """Configure the root logger with JSON formatting. Call once at entry
     points that do NOT run under uvicorn (CLI scripts, cron oneshots, tests).

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -7,7 +7,12 @@ import logging
 import logging.config
 from pathlib import Path
 
-from src.core.logging import build_json_formatter, configure_logging, get_logger
+from src.core.logging import (
+    ColorMessageFilter,
+    build_json_formatter,
+    configure_logging,
+    get_logger,
+)
 
 LOG_CONFIG_PATH = Path("src/core/log_config.json")
 
@@ -41,8 +46,13 @@ def test_uvicorn_log_config_is_valid_and_shares_formatter():
         for f in config["formatters"].values()
     )
     # All three uvicorn loggers must be present, else they keep the plain default.
+    # Pin placement, not just effect: the color_message strip must sit on each
+    # logger (mutates the record at its source), never on the stdout handler —
+    # a handler-scoped strip resurrects the field the day a sink builds its
+    # payload from record.__dict__ instead of a Formatter (OTel's LoggingHandler).
     for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
         assert name in config["loggers"]
+        assert "strip_color_message" in config["loggers"][name]["filters"]
 
     names = ("", "uvicorn", "uvicorn.error", "uvicorn.access")
     saved = {
@@ -50,17 +60,60 @@ def test_uvicorn_log_config_is_valid_and_shares_formatter():
             logging.getLogger(n).handlers[:],
             logging.getLogger(n).propagate,
             logging.getLogger(n).level,
+            logging.getLogger(n).filters[:],
         )
         for n in names
     }
     try:
         logging.config.dictConfig(config)  # raises on a malformed config
     finally:
-        # Restore level too: dictConfig sets root + uvicorn loggers to INFO,
-        # and leaking that into later tests would be an order-dependent flake.
-        for n, (handlers, propagate, level) in saved.items():
+        # Restore level AND filters: dictConfig sets root + uvicorn loggers to
+        # INFO and attaches the strip filter, and leaking either into later
+        # tests would be an order-dependent flake (same class as the #378 .level
+        # restore).
+        for n, (handlers, propagate, level, filters) in saved.items():
             lg = logging.getLogger(n)
             lg.handlers, lg.propagate, lg.level = handlers, propagate, level
+            lg.filters = filters
+
+
+def test_color_message_filter_strips_extra_from_record():
+    """uvicorn attaches an ANSI-coloured duplicate of its lifecycle lines as
+    `extra={"color_message": ...}`; the filter drops it at the record source so
+    no handler ever serializes it. Asserting on the record itself (not the JSON
+    output) proves the strip is sink-independent, not formatter-dependent."""
+    record = logging.LogRecord(
+        name="uvicorn.error",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Started server process [%d]",
+        args=(4066888,),
+        exc_info=None,
+    )
+    record.color_message = "Started server process [\033[36m%d\033[0m]"
+
+    assert ColorMessageFilter().filter(record) is True
+    assert not hasattr(record, "color_message")
+
+    parsed = json.loads(build_json_formatter().format(record))
+    assert parsed["message"] == "Started server process [4066888]"
+    assert "color_message" not in parsed
+
+
+def test_color_message_filter_passes_records_without_the_extra():
+    """A record with no color_message is passed through untouched — filter()
+    never drops a record."""
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="plain",
+        args=(),
+        exc_info=None,
+    )
+    assert ColorMessageFilter().filter(record) is True
 
 
 def test_shared_formatter_renders_uvicorn_access_record():

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.18.3"
+version = "0.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Backport of gregoryfoster/skills#82. Closes #383.

## Problem

The `--log-config` unification (#378) left uvicorn's `color_message` extra reaching the JSON payload. Every `uvicorn.error` lifecycle record carried a second copy of its message with raw ANSI escapes (`color_message`: `"Started server process [<ESC>[36m%d<ESC>[0m]"`). Access records were unaffected (they pass no `extra=`).

## Fix

- **`src/core/logging.py`** — `ColorMessageFilter(logging.Filter)` pops `color_message` off the record, returns `True` (never drops).
- **`src/core/log_config.json`** — `filters` block + `"filters": ["strip_color_message"]` on all three uvicorn loggers.

**Why a filter on the loggers, not the handler or `reserved_attrs`:** stripping at the record source mutates it once before any handler reads it. A handler-scoped strip works today but resurrects the field the day a sink builds its payload from `record.__dict__` — exactly what OTel's `LoggingHandler` does, against a reserved list that doesn't cover `color_message`. All three loggers need it because a logger's filters run only for records logged *through* that logger, and propagation walks ancestors' **handlers**, never their filters.

## Tests (`tests/core/test_logging.py`)

- Filter strips the attribute **from the record itself** (proves sink-independence) and formats to clean JSON; passes records without the extra untouched.
- Log-config test now asserts `strip_color_message` is on each of `uvicorn`/`uvicorn.error`/`uvicorn.access` — pins **placement**, so moving it to the handler fails.
- `dictConfig` save/restore extended to cover `.filters` (avoids leaking a filter into later tests — same order-dependent flake class as the #378 `.level` restore).

## Verification

Live `dictConfig` emit of a `uvicorn.error` record with a `color_message` extra → keys exactly `{level, logger, message, timestamp}`, zero `color_message`, zero ANSI bytes. 5/5 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
