### PR TITLE
#387 docs: correct changes-outbox contract (at-least-once, retention, rewind-replay)

### DIFF
--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -269,7 +269,7 @@ GET /api/v1/subscriptions/discover
 
 `merged_into` is `null` for genuine deletes and for all `"updated"` events. When `change_kind` is `"deleted"` and the entity was merged rather than hard-deleted, `merged_into` contains the id of the winner entity of the same type — the subscriber should re-anchor its reference to that id rather than retiring the entity locally.
 
-`seq_id` is a monotonically increasing integer from the outbox log (`BIGSERIAL`). It is stable and gapless per subscription set.
+`seq_id` is a strictly increasing integer from the append-only outbox log (`BIGSERIAL`). It is **monotonic**, not gapless — the log is an offset cursor, not a contiguous counter. Do not infer "missed events" from a gap between consecutive `seq_id`s: the sequence skips values for rolled-back or failed writes, and the id space is global across all entities while your feed is subscription-filtered, so consecutive delivered ids are expected to jump. See **Delivery semantics** below for the exactly-what-is-guaranteed contract (it is *at-least-once*, not exactly-once) — read it before building a consumer that trims or removes a reconciliation backstop.
 
 ### Polling pattern
 
@@ -303,10 +303,31 @@ while True:
 
 - **Exclusive cursor.** `after` uses `>` semantics — `next_after` will never appear again in the next page.
 - **Subscription-filtered.** Events for entities not in the subscription set are never returned, regardless of cursor.
-- **Retention window — the feed is recent-changes, not a permanent event store.** Outbox rows older than ~90 days are pruned (issue #204). Polling from `after=0` returns every *retained* event for your subscribed entities (the subscription filter applies at query time), but only within that window — it is **not** a full-history backfill. To obtain the **current state** of a newly subscribed entity (including one unchanged for longer than the window, which therefore has no recent outbox row), fetch it directly from its read endpoint, then poll incrementally from the returned `next_after`. A consumer dark longer than the retention window may miss intervening events and must full-reconcile against the read endpoints.
-- **Deleted entities.** Hard deletes and merges write a tombstone to an internal `deleted_entities` table for all five entity types (`person`, `organization`, `jurisdiction`, `role`, `role_assignment` — the latter two since #277), pruned on the same ~90-day TTL as the outbox (issue #204). After the TTL, `GET /api/v1/people/{id}` or `/orgs/{id}` returning 404 is the fallback signal that an entity was removed.
-- **Order.** Results are ordered by outbox `seq_id ASC` — strictly monotonic, no ties.
+- **Retention window — the feed is recent-changes, not a permanent event store.** Outbox rows older than **90 days** (age-based, pruned daily by `changed_at`; size-unbounded, issue #204) are deleted. Polling from `after=0` returns every *retained* event for your subscribed entities (the subscription filter applies at query time), but only within that window — it is **not** a full-history backfill. To obtain the **current state** of a newly subscribed entity (including one unchanged for longer than the window, which therefore has no recent outbox row), fetch it directly from its read endpoint, then poll incrementally from the returned `next_after`. A consumer dark longer than the retention window may miss intervening events and must full-reconcile against the read endpoints.
+- **Falling off the horizon is silent.** If your persisted `after` predates the prune horizon, `GET /changes` does **not** error or reset — it simply returns the oldest *surviving* rows with `id > after`. You cannot distinguish "nothing changed since `after`" (empty page, `next_after` echoes `after`) from "events between `after` and the oldest retained row were pruned" (non-empty page whose first `seq_id` is far above `after`) from the response alone. There is currently no oldest-retained watermark in `meta`. If your poll cadence could ever exceed the retention window, treat a resume where the first returned `seq_id` jumps well past your stored `after` as "possibly lost the tail" and full-reconcile.
+- **Deleted entities.** Hard deletes and merges write a tombstone to an internal `deleted_entities` table for all five entity types (`person`, `organization`, `jurisdiction`, `role`, `role_assignment` — the latter two since #277), pruned on the same 90-day TTL as the outbox (issue #204). After the TTL, `GET /api/v1/people/{id}` or `/orgs/{id}` returning 404 is the fallback signal that an entity was removed.
+- **Order.** Results are ordered by outbox `seq_id ASC`. Monotonic within a page and across pages, but see **Delivery semantics** for the concurrent-writer caveat that makes a purely incremental cursor *not* strictly complete.
 - **No total count.** `meta.count` is the page count, not a dataset total.
+
+### Delivery semantics
+
+The feed is a Postgres `BIGSERIAL`-backed outbox written by row-level triggers, not a broker with broker guarantees. What is and is not promised:
+
+- **At-least-once, per row-level change — not exactly-one-per-mutation.** Every committed `INSERT`/`UPDATE` of a tracked entity row emits one outbox row; there is **no coalescing** (N updates → N rows), so the latest state is always reachable, but a single logical write can emit several rows for one entity (a direct field update plus touch-cascade bumps from its child tables — names, identifiers, links, contacts, citations; #327). Consumers must be idempotent: treat each event as "re-fetch this entity," keyed on `(entity_type, entity_id)`, not as a delta to apply once.
+- **Concurrent-writer skip — the one real completeness hazard.** A `seq_id` is assigned when the writer's transaction inserts the outbox row, but only becomes *visible* on commit. If transaction A acquires a lower `seq_id` than concurrently-running B, and B commits first, a consumer can read B, advance `next_after` past A's id, and then A commits — A's row now exists but is *below* the cursor and a purely incremental poller will never see it. Under the production multi-worker deployment this window is real (bounded by the longest in-flight write, e.g. a bulk import transaction). **Mitigation:** periodically rewind — re-poll from `high_water − margin` — where `margin` comfortably exceeds your longest expected write/import transaction. Rewind is idempotent (see above) and is the intended way to close this gap; the exclusive-cursor incremental poll alone does not.
+- **No-emit cases the feed does not cover** (a reconciliation backstop, however infrequent, must still account for these):
+  - Trigger-suppressed bulk paths: `TRUNCATE`, `session_replication_role = 'replica'`, `ALTER TABLE ... DISABLE TRIGGER`, or `COPY` into a trigger-disabled table produce no rows. (Ordinary bulk `UPDATE`/backfills fire per row and *over*-emit, not under.)
+  - Hard deletes emit only via the `deleted_entities` tombstone (the entity trigger is `INSERT OR UPDATE`, not `DELETE`); any delete path that bypasses the tombstone emits nothing.
+  - Trigger-less ingestion telemetry (`field_confidence`, `import_provenance`) does not touch the parent row and so emits nothing — by design; not user-facing state.
+
+### Rewind-and-replay reconciliation (recommended over full-cohort re-fetch)
+
+Because the feed is at-least-once and idempotent, a consumer does **not** need to periodically re-fetch its entire produced cohort by id purely as a safety net. Instead:
+
+1. Poll incrementally from `next_after` for the steady-state deltas.
+2. On a periodic cadence, **rewind**: re-poll from `seq = high_water − margin`. This re-covers the concurrent-writer skip window and any near-horizon churn at O(events-in-window) instead of O(cohort).
+3. Choose `margin` so it exceeds your longest expected in-flight write/import transaction, and keep your rewind cadence comfortably under `90 days − margin` so you never rewind into pruned range.
+4. Keep a **low-frequency** full reconcile (or a 404-driven check against read endpoints) only for the residual the outbox cannot signal — the no-emit cases above. Right-size it against that boundary; the outbox lets you shrink it, not necessarily remove it.
 
 ---
 


### PR DESCRIPTION
Closes #387.

## What

Documentation-only fix to the `/api/v1/changes` reference in `docs/PUBLIC_API.md`. #387 asked us to confirm and document two outbox guarantees before a downstream consumer (usa-wa#159) drops its O(cohort) full-refetch backstop for a cheaper rewind-and-replay. Tracing the implementation surfaced that the existing doc **overstated** the contract.

## Findings (from the code)

Outbox = `entity_changes` `BIGSERIAL id` + row-level `AFTER INSERT OR UPDATE` triggers on the six entity tables + tombstone trigger on `deleted_entities`. Feed query is `WHERE id > $after ORDER BY id ASC LIMIT`. Prune = daily 90-day age-based `DELETE ... WHERE changed_at < now()-90d`.

**Q1 — gapless / exactly-one-per-mutation:**
- Monotonic ✅ but **not gapless** — `BIGSERIAL` skips rolled-back/failed writes; global id space vs subscription-filtered feed makes id jumps normal.
- **No coalescing** — N updates → N rows, latest always reachable; one logical write can emit several rows (direct update + #327 ancillary touch-cascade). ⇒ **at-least-once**, be idempotent.
- **Concurrent-writer skip** — seq assigned at insert, visible at commit; a low-seq txn committing after a higher one already consumed by the cursor is permanently skipped by a purely incremental poller. This is the real completeness hazard; rewind covers it.
- **No-emit cases** — trigger-suppressed bulk paths (`TRUNCATE`/`DISABLE TRIGGER`/`replica`), tombstone-bypass deletes, trigger-less telemetry (`field_confidence`/`import_provenance`).

**Q2 — retention:**
- 90-day age-based, size-unbounded. `after=0` = retained window only, not full history.
- Falling off the horizon is **silent** — no error, no reset, no watermark in `meta`; consumer resumes at oldest-retained unaware of the gap.

## Changes

- Rewrote the `seq_id` guarantee line (monotonic, not gapless).
- New **Delivery semantics** section: at-least-once, concurrent-writer skip + rewind mitigation, the no-emit set.
- New **Rewind-and-replay reconciliation** subsection: O(cohort) → O(events-in-window), with margin/cadence guidance and a right-sized (not removed) residual backstop.
- Retention bullet: made the horizon behavior explicit + added a "silent fall-off" bullet.

## Follow-up

#388 — expose an oldest-retained watermark (`min_seq`) in `/changes` `meta` so consumers can *detect* horizon fall-off rather than infer it. That closes the one gap this PR could only document, not fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)