### PR TITLE
#386 chore: migrate skills refresh to the SessionStart auto-refresh hook

### DIFF
--- a/.claude/hooks/skills-submodule-update.sh
+++ b/.claude/hooks/skills-submodule-update.sh
@@ -1,0 +1,1 @@
+../../skills-vendor/gregoryfoster-skills/skills/managing-skills/scripts/skills-submodule-update.sh

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,14 +16,13 @@
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/a11y-status-reminder.sh"
           }
         ]
-      }
-    ],
-    "UserPromptSubmit": [
+      },
       {
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
-            "command": "LOCK=\"/tmp/pm-submodule-update-$(date +%Y%m%d)\"; if [ ! -f \"$LOCK\" ]; then git submodule update --remote --merge skills-vendor/gregoryfoster-skills skills-vendor/obra-superpowers && touch \"$LOCK\" && if ! git diff --quiet HEAD skills-vendor/gregoryfoster-skills skills-vendor/obra-superpowers 2>/dev/null; then git add skills-vendor/gregoryfoster-skills skills-vendor/obra-superpowers && git commit -m 'chore: update skills submodules'; fi; fi"
+            "command": "bash .claude/hooks/skills-submodule-update.sh"
           }
         ]
       }

--- a/.skills/doctor.sh
+++ b/.skills/doctor.sh
@@ -15,6 +15,9 @@
 # `git submodule update --init --recursive` if any dangle, and prints a
 # clear actionable error if self-healing fails.
 #
+# Because the installed copy is a copy, it re-syncs itself from the vendored
+# source whenever that source is reachable — see sync_self below.
+#
 # Designed for use as a Phase 1 preflight in every reviewing-* / shipping-*
 # SKILL.md invocation. The doctor runs first so that the resolution loop that
 # follows sees a freshly healed symlink chain (issue #63):
@@ -28,7 +31,11 @@
 # Usage: bash .skills/doctor.sh [--check-only] [--verbose] [--no-preflight] [--help]
 set -euo pipefail
 
-VERSION="2026-05-28-6"
+# Diagnostic stamp only — reported by --version so a bug report can name the
+# copy that produced it. Nothing branches on it: sync_self keeps the installed
+# copy equal to the vendored source, which makes drift transient and a
+# version-comparison mechanism unnecessary.
+VERSION="2026-08-04-2"
 
 CHECK_ONLY=0
 VERBOSE=0
@@ -50,6 +57,12 @@ present, runs 'git submodule update --init --recursive' and re-checks.
 Exits 0 silently when healthy. Exits non-zero with an actionable error
 when self-healing fails or is not possible (e.g. no .git directory).
 
+Re-syncs .skills/doctor.sh from the vendored source under skills-vendor/
+when the two differ, so upstream fixes reach consumers that did not
+install the auto-refresh hook. Best-effort — never affects the exit code;
+failures are reported only under --verbose. The refresh applies from the
+following run. Skipped entirely under --check-only, which makes no writes.
+
 When submodule init fails with a well-known SSH/HTTPS auth signature
 (Permission denied, Could not read from remote repository, Authentication
 failed for 'https://'), a targeted remediation block is printed instead
@@ -59,14 +72,15 @@ the agent isn't reachable from this shell. A separate remediation block
 covers host-key-verification failures (ssh-keyscan-based fix).
 
 Options:
-  --check-only    Report broken symlinks but do not run submodule init
-                  (overridden by the archive-checkout path when .git is
-                  absent — the archive case prints its own diagnosis).
+  --check-only    Report broken symlinks but make no changes: no submodule
+                  init, no self-sync. (The archive-checkout path when .git
+                  is absent overrides the reporting, printing its own
+                  diagnosis — it makes no changes either.)
   --no-preflight  Skip the SSH pre-flight ping. Useful when the operator
                   knows the agent state and doesn't want the 3-second
                   ConnectTimeout on every invocation.
   --verbose, -v   Print resolution details even when healthy.
-  --version       Print script version and exit.
+  --version       Print the script's diagnostic version stamp and exit.
   --help, -h      Show this help and exit.
 
 Exit codes:
@@ -89,6 +103,83 @@ done
 # root, but we tolerate being called from a subdirectory.
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$ROOT"
+
+# Re-sync the installed copy of this script from the vendored source.
+#
+# The doctor is installed as a real file rather than a symlink so it stays
+# reachable when the vendor submodule is uninitialized — the exact state it
+# exists to repair. The cost of that choice is drift: upstream fixes reach a
+# consumer only when something re-runs install-doctor.sh. The auto-refresh
+# hook does that each session, but consumers that declined the hook would
+# otherwise run a stale doctor indefinitely (issue #84). Since every
+# reviewing-* / shipping-* preflight invokes the doctor, this is the one code
+# path guaranteed to run in a hook-less consumer.
+#
+# The vendored copy is authoritative and CONTENT decides, not mtime. Git sets
+# mtimes at checkout time, so a freshly-initialized submodule always looks
+# "newer" and a deliberate submodule rollback always looks "older" — an mtime
+# comparison misfires in both directions. Content equality also gives pinning
+# the right semantics: a consumer pinned to an older submodule gets that
+# older doctor, which is what pinning means.
+#
+# Wholly best-effort. A missing vendor, a missing installer, a destination
+# the installer refuses to clobber, or a failed copy must all leave this
+# script's exit code untouched: Phase 1 preflights invoke the doctor with
+# `|| exit 1`, so a self-sync failure would otherwise block a review over
+# something cosmetic.
+sync_self() {
+  # --check-only is contractually non-mutating — it is the mode a CI health
+  # probe reaches for, and .skills/doctor.sh is a tracked file, so a write
+  # here would dirty the working tree and trip a `git diff --exit-code`
+  # cleanliness gate on the next submodule bump, with nothing connecting the
+  # failure back to the bump.
+  if [ "$CHECK_ONLY" = "1" ]; then
+    return 0
+  fi
+
+  local self="$ROOT/.skills/doctor.sh"
+  # Only refresh an already-installed doctor — never create one. Installation
+  # is Step 2c's job (and the hook's); a preflight shouldn't materialize files
+  # the operator didn't ask for. In the preflight path this always exists,
+  # since that path tests `-x .skills/doctor.sh` before invoking us.
+  [ -f "$self" ] || return 0
+
+  local src installer out rc
+  # First matching vendor wins, matching skills-submodule-update.sh's `break`.
+  # When skills-vendor/ is absent the glob stays unexpanded and the -f test
+  # rejects the literal string, so the loop falls through to `return 0`.
+  for src in skills-vendor/*/skills/managing-skills/scripts/doctor.sh; do
+    [ -f "$src" ] || continue
+    if cmp -s "$src" "$self"; then
+      return 0
+    fi
+    installer="$(dirname "$src")/install-doctor.sh"
+    [ -f "$installer" ] || return 0
+
+    # Capture rather than discard. A permanently-failing sync is otherwise
+    # invisible: a consumer with a user-authored file at .skills/doctor.sh
+    # can never receive doctor updates, and the installer's precise
+    # explanation of why would go to /dev/null on every preflight forever.
+    # Surfaced only under --verbose so the default path stays quiet.
+    # `--quiet` means a successful run produces no output, so `out` is
+    # non-empty only when something went wrong.
+    rc=0
+    out="$(bash "$installer" --quiet 2>&1)" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      echo "doctor: refreshed .skills/doctor.sh from $src — the update applies from the next run" >&2
+    elif [ "$VERBOSE" = "1" ]; then
+      echo "doctor: self-sync failed (rc=$rc); the installed copy is unchanged:" >&2
+      printf '%s\n' "$out" >&2
+    fi
+    return 0
+  done
+  return 0
+}
+
+# Call site 1 of 2: the healthy path exits early a few lines below, which is
+# the overwhelming majority of invocations. A self-sync placed after the heal
+# logic would almost never run.
+sync_self
 
 # Nothing to check if the consumer doesn't use the skills/ pattern.
 if [ ! -d skills ]; then
@@ -332,6 +423,10 @@ if [ "$RC" -ne 0 ]; then
   fi
   exit 1
 fi
+
+# Call site 2 of 2: the vendor tree may have only just become readable — call
+# site 1 ran before the init and would have found nothing to sync against.
+sync_self
 
 # Re-check after self-heal.
 scan_broken

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -22,7 +22,24 @@ Local overrides in `skills/` automatically shadow vendor skills in both systems.
 
 Init after cloning: `git submodule update --init --recursive`
 
-Submodule freshness auto-enforced by `UserPromptSubmit` hook in `.claude/settings.json`. Force-refresh: `git submodule update --remote --merge skills-vendor/gregoryfoster-skills skills-vendor/obra-superpowers`
+### Auto-refresh hook (#386)
+
+Submodule freshness is maintained by the vendored `SessionStart` hook `.claude/hooks/skills-submodule-update.sh` — a **symlink** into `skills-vendor/gregoryfoster-skills/skills/managing-skills/scripts/`, so upstream fixes to the hook arrive with the next submodule bump.
+
+- Once per UTC day (`.git/skills-update.lock`), `main` only, scoped to `skills-vendor/` — never other submodules
+- Auto-commits the pointer bump (`chore: update skills submodules`); logs to `.git/skills-update.log`
+- Exits `0` on every non-fatal condition — a session can never be blocked by it
+- Opportunistically runs `install-doctor.sh` on **every** branch (not day-gated) so `.skills/doctor.sh` self-heals; the commit of that refresh stays behind the `main`-only + daily gates
+
+Replaced the legacy inline `UserPromptSubmit` one-liner, which committed submodule bumps on any branch and never refreshed the doctor. Do not re-add it — two mechanisms racing on the same submodule.
+
+The `command` string is the literal `bash .claude/hooks/skills-submodule-update.sh` (project-dir-relative, not `$CLAUDE_PROJECT_DIR`-prefixed like the other hooks): `managing-skills` keys its idempotence and uninstall jq on that exact string.
+
+Force-refresh: `git submodule update --remote --merge -- skills-vendor/`
+
+### Doctor
+
+`.skills/doctor.sh` diagnoses and repairs broken vendor symlinks / uninitialized submodules. It is a real **file copy**, not a symlink — a symlinked doctor would dangle in exactly the failure mode it exists to repair — and re-syncs itself from the vendored source on every run (upstream skills#84). Check with `bash .skills/doctor.sh --version`; silent + exit `0` means healthy.
 
 To add a new external skill repo: follow the `managing-skills` skill.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.22.2"
+version = "0.22.3"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.22.2"
+version = "0.22.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Closes #386.

## Problem

The repo refreshed skills submodules with a **legacy inline `UserPromptSubmit` one-liner** that predates the doctor entirely. It bumped submodule pointers but never ran `install-doctor.sh`, so the vendored skills advanced while `.skills/doctor.sh` stayed frozen at `VERSION=2026-05-28-6` — missing upstream [gregoryfoster/skills#84](https://github.com/gregoryfoster/skills/issues/84)'s self-syncing doctor. It also committed pointer bumps on *any* branch, unbounded and unlogged.

## Change

| | |
|---|---|
| `.claude/hooks/skills-submodule-update.sh` | **new** — symlink → `skills-vendor/gregoryfoster-skills/skills/managing-skills/scripts/skills-submodule-update.sh` (committed as mode `120000`), so upstream fixes arrive by submodule bump |
| `.claude/settings.json` | `SessionStart` entry merged in (jq merge, preserves the two existing hooks); legacy `UserPromptSubmit` entry removed — leaving both would race two mechanisms on the same submodule |
| `.skills/doctor.sh` | refreshed `2026-05-28-6` → **`2026-08-04-2`** (self-syncing) via `install-doctor.sh` |
| `docs/SKILLS.md` | documents the hook, its gates, the literal-command contract, and the doctor |

New hook gates, vs. the one-liner it replaces: once per UTC day (`.git/skills-update.lock`), `main` only, scoped to `skills-vendor/`, logged to `.git/skills-update.log` (truncated at 64 KiB), exits `0` on every non-fatal condition. `install-doctor.sh` runs on **every** branch (working-tree repair, not day-gated); the *commit* of that refresh stays behind the `main`-only + daily gates.

**No submodule bump needed** — the pointer (`549a88b`) already contains `e03adc3`, so issue step 1 was already satisfied.

The hook `command` is the literal `bash .claude/hooks/skills-submodule-update.sh` — project-dir-relative, deliberately *not* `$CLAUDE_PROJECT_DIR`-prefixed like the repo's other two hooks. `managing-skills` keys both its Step 0 idempotence check and its uninstall `jq` on that exact string; rewriting it would silently break re-runs and uninstall. Noted in `docs/SKILLS.md`.

## Verification

```
$ bash .skills/doctor.sh --version
2026-08-04-2

$ bash .skills/doctor.sh          # silent + exit 0 = healthy
$ echo $?
0

$ git status --porcelain          # clean
```

- Symlink resolves (`test -f` OK); committed as a symlink, not a copy.
- Hook run on this non-`main` branch: silent, `exit 0` — the `main`-only gate holds.
- Doctor's self-repair exercised for real: on first run in the fresh worktree it detected the dangling `obra-superpowers` symlink and initialized the submodule itself.
- `.claude/settings.json` parses; the two pre-existing `SessionStart` hooks are untouched.
- Full pre-commit suite green (ruff lint + format, pytest unit, vitest, version sync).

Version bumped `0.22.2` → `0.22.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)