### PR TITLE
#347 fix: check gh return codes before claiming an alert was raised

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.26.0"
+version = "0.26.1"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/check_ready.py
+++ b/scripts/check_ready.py
@@ -221,8 +221,15 @@ def surface(ok: bool, summary: str, *, runner=None) -> None:
                 "(deliberately not published — this is a public repo). "
                 "Automated by `power-map-ready.timer` (#347)."
             )
-            runner(["issue", "create", "--title", ISSUE_TITLE, "--label", LABEL, "--body", body])
-            logger.warning("opened %s issue", LABEL)
+            rc, _ = runner(
+                ["issue", "create", "--title", ISSUE_TITLE, "--label", LABEL, "--body", body]
+            )
+            if rc == 0:
+                logger.warning("opened %s issue", LABEL)
+            else:
+                # Say what happened, not what was attempted: the next run will
+                # find no open issue and try again.
+                logger.warning("gh issue create failed (rc=%d) — no alert raised", rc)
         elif existing:
             runner(
                 [
@@ -233,8 +240,11 @@ def surface(ok: bool, summary: str, *, runner=None) -> None:
                     f"✅ **Recovered** — `/ready` green as of {timestamp}. Auto-closing.",
                 ]
             )
-            runner(["issue", "close", existing])
-            logger.info("closed recovered readiness issue #%s", existing)
+            rc, _ = runner(["issue", "close", existing])
+            if rc == 0:
+                logger.info("closed recovered readiness issue #%s", existing)
+            else:
+                logger.warning("gh issue close failed (rc=%d) — issue #%s left open", rc, existing)
     except Exception:
         # A broken gh must not turn a real outage into a clean exit.
         logger.warning("GitHub surfacing failed — probe result stands", exc_info=True)

--- a/tests/scripts/test_check_ready.py
+++ b/tests/scripts/test_check_ready.py
@@ -304,6 +304,46 @@ def test_surface_creates_the_label_idempotently():
     assert runner.ran("label", "create", LABEL)
 
 
+def test_surface_does_not_claim_to_have_opened_when_create_fails(caplog):
+    """A failed create must read as failed.
+
+    Found in production during the #347 install self-test: the journal said
+    "opened ready-regression issue" on a run whose return code was never
+    inspected. A log line that reports an unchecked outcome is worse than
+    silence — it is the one an operator trusts while no alert exists.
+    """
+    runner = _Runner((0, LABEL), (0, ""), (1, ""))  # label list, issue list, create FAILS
+    with caplog.at_level(logging.INFO):
+        surface(False, "not ready: pool_timeout", runner=runner)
+    messages = [r.getMessage().lower() for r in caplog.records]
+    assert any("failed" in m for m in messages)
+    assert not any("opened" in m for m in messages)
+
+
+def test_surface_reports_a_successful_open(caplog):
+    runner = _Runner((0, LABEL), (0, ""), (0, ""))
+    with caplog.at_level(logging.INFO):
+        surface(False, "not ready: pool_timeout", runner=runner)
+    assert any("opened" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_surface_does_not_claim_to_have_closed_when_close_fails(caplog):
+    """Same rule on the recovery side — a stale alert must not read as cleared."""
+    runner = _Runner((0, LABEL), (0, "412"), (0, ""), (1, ""))  # ... comment ok, close FAILS
+    with caplog.at_level(logging.INFO):
+        surface(True, "", runner=runner)
+    messages = [r.getMessage().lower() for r in caplog.records]
+    assert any("failed" in m for m in messages)
+    assert not any("closed recovered" in m for m in messages)
+
+
+def test_surface_reports_a_successful_close(caplog):
+    runner = _Runner((0, LABEL), (0, "412"), (0, ""), (0, ""))
+    with caplog.at_level(logging.INFO):
+        surface(True, "", runner=runner)
+    assert any("closed recovered" in r.getMessage().lower() for r in caplog.records)
+
+
 # --- main ------------------------------------------------------------------
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.26.0"
+version = "0.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Follow-up to #411, found while running the install self-test on the VM.

## The defect

`surface()` logged `opened ready-regression issue` on a path that never inspected `gh`'s return code:

```python
runner(["issue", "create", ...])
logger.warning("opened %s issue", LABEL)
```

The create succeeded that time, so the claim was true by luck. On a `gh` failure — expired token, rate limit, network — the journal would have said an alert was raised while none existed. That is worse than silence: it is the line an operator trusts during an outage.

Same shape on the recovery side, where a failed `close` would still log `closed recovered readiness issue`, reporting a cleared alert that is still open.

## The fix

Both write paths branch on rc. A failed create logs `no alert raised` — the next run finds nothing open and retries, so the guard self-heals. A failed close says the issue was left open.

Two new tests assert the *negative*: that a failed call does not produce a success line. Both fail against the previous implementation.

39 tests pass. The behaviour only diverges when `gh` itself fails, so this is covered by unit tests rather than a live rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)