### PR TITLE
fix: CR round 1 — guard input validation, flag precedence, paging, escaping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.29.0"
+version = "0.29.1"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/_alerting.py
+++ b/scripts/_alerting.py
@@ -119,7 +119,7 @@ def surface(ok: bool, summary: str, *, alert: Alert, runner=None) -> None:
                 # The next run finds nothing open and tries again.
                 logger.warning("gh issue create failed (rc=%d) — no alert raised", rc)
         elif existing:
-            runner(
+            rc, _ = runner(
                 [
                     "issue",
                     "comment",
@@ -129,6 +129,10 @@ def surface(ok: bool, summary: str, *, alert: Alert, runner=None) -> None:
                     "Auto-closing.",
                 ]
             )
+            if rc != 0:
+                # Closing is what clears the alert, so press on regardless —
+                # but say the note is missing rather than implying it landed.
+                logger.warning("gh issue comment failed (rc=%d) — closing anyway", rc)
             rc, _ = runner(["issue", "close", existing])
             if rc == 0:
                 logger.info("closed recovered issue #%s", existing)

--- a/scripts/_do_api.py
+++ b/scripts/_do_api.py
@@ -16,6 +16,8 @@ from urllib.request import urlopen
 API_ROOT = "https://api.digitalocean.com/v2"
 DEFAULT_CLUSTER = "co-pm-db-1"
 DEFAULT_TIMEOUT = 30.0
+# Large enough that a single page covers any realistic account.
+PAGE_SIZE = 200
 
 
 def _request(url: str, token: str) -> urllib.request.Request:
@@ -37,8 +39,14 @@ def fetch_allowed_ips(
     so they must not reach ``allowed_external_ips`` or an egress comparison.
     """
     opener = opener or urlopen
-    clusters = _get(f"{API_ROOT}/databases", token, opener=opener, timeout=timeout)
-    match = next((c for c in clusters.get("databases", []) if c.get("name") == cluster_name), None)
+    # DO pages at 20 by default, so a cluster past page 1 used to look absent
+    # (CR1 finding 3). Ask for a large page, then follow the cursor anyway.
+    url = f"{API_ROOT}/databases?per_page={PAGE_SIZE}"
+    match = None
+    while url and match is None:
+        page = _get(url, token, opener=opener, timeout=timeout)
+        match = next((c for c in page.get("databases", []) if c.get("name") == cluster_name), None)
+        url = page.get("links", {}).get("pages", {}).get("next")
     if match is None:
         raise LookupError(f"no DigitalOcean database cluster named {cluster_name!r}")
     firewall = _get(

--- a/scripts/check_egress_ip.py
+++ b/scripts/check_egress_ip.py
@@ -98,7 +98,14 @@ UNRESTRICTED = "unrestricted"
 UNKNOWN = ""
 
 
-def resolve_allowlist(token: str, cluster: str, expected_raw: str) -> tuple[set[str] | None, str]:
+def resolve_allowlist(
+    token: str,
+    cluster: str,
+    expected_raw: str,
+    *,
+    explicit: bool = False,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> tuple[set[str] | None, str]:
     """Return (allowlist, source label), preferring the live Trusted Sources.
 
     The DO API is authoritative and needs nothing kept in sync by hand, so it
@@ -108,10 +115,20 @@ def resolve_allowlist(token: str, cluster: str, expected_raw: str) -> tuple[set[
 
     ``EGRESS_EXPECTED_IPS`` remains the fallback for a host with no token, or
     for an API that is temporarily unreachable.
+
+    An **explicitly passed** ``--expected`` overrides all of that: the operator
+    is debugging, and a flag that silently loses to the API lies about what it
+    compared (CR1 finding 2). The env var is not explicit and still loses.
     """
+    if explicit:
+        # An explicit but empty set asks to compare against nothing — report it
+        # as undetermined rather than declaring drift against an empty list.
+        return (parse_expected(expected_raw) or None), (
+            "--expected" if expected_raw.strip() else UNKNOWN
+        )
     if token:
         try:
-            live = fetch_allowed_ips(token, cluster)
+            live = fetch_allowed_ips(token, cluster, timeout=timeout)
         except Exception:
             logger.warning("DO API allowlist lookup failed — falling back", exc_info=True)
         else:
@@ -133,8 +150,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Detect egress-IP drift (#410)")
     parser.add_argument(
         "--expected",
-        default=os.environ.get("EGRESS_EXPECTED_IPS", ""),
-        help="comma-separated IPs the database allowlist knows (env EGRESS_EXPECTED_IPS)",
+        default=None,
+        help="comma-separated IPs to compare against; overrides the DO API "
+        "(env EGRESS_EXPECTED_IPS supplies a fallback, which does not)",
     )
     parser.add_argument(
         "--timeout",
@@ -168,7 +186,11 @@ def main() -> None:
         return
 
     allowed, source = resolve_allowlist(
-        os.environ.get("DO_API_TOKEN", ""), args.cluster, args.expected
+        os.environ.get("DO_API_TOKEN", ""),
+        args.cluster,
+        args.expected if args.expected is not None else os.environ.get("EGRESS_EXPECTED_IPS", ""),
+        explicit=args.expected is not None,
+        timeout=args.timeout,
     )
     if source == UNRESTRICTED:
         logger.info(

--- a/scripts/check_ready.py
+++ b/scripts/check_ready.py
@@ -207,6 +207,11 @@ def main() -> None:
         "--no-gh", action="store_true", help="skip GitHub surfacing (env READY_CHECK_NO_GH)"
     )
     args = parser.parse_args()
+    if args.attempts < 1:
+        # Zero probed nothing and then crashed on results[-1] (CR1 finding 1).
+        # An env typo must not turn the outage guard into a trap that never
+        # makes a request.
+        parser.error(f"--attempts must be at least 1 (got {args.attempts})")
     no_gh = args.no_gh or bool(os.environ.get("READY_CHECK_NO_GH"))
 
     if os.environ.get("READY_CHECK_FORCE_FAIL"):

--- a/scripts/write_terraform_credentials.py
+++ b/scripts/write_terraform_credentials.py
@@ -33,6 +33,7 @@ Usage:
 """
 
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -72,9 +73,12 @@ def render_tfvars(token: str, allowed_ips: list[str]) -> str:
         raise ValueError(
             "allowed_external_ips would be empty — the cluster would become unreachable"
         )
-    entries = ", ".join(f'"{ip}"' for ip in allowed_ips)
+    # json.dumps yields a correctly-escaped HCL string literal. A raw f-string
+    # let a quote in the value end the literal early and append arbitrary HCL
+    # (CR1 finding 6).
+    entries = ", ".join(json.dumps(ip) for ip in allowed_ips)
     return (
-        f'do_token = "{token}"\n\n'
+        f"do_token = {json.dumps(token)}\n\n"
         "# Mirrors DO -> Databases -> Settings -> Trusted Sources, read from the API\n"
         f"# by scripts/write_terraform_credentials.py (#409).\n"
         f"allowed_external_ips = [{entries}]\n"
@@ -83,7 +87,7 @@ def render_tfvars(token: str, allowed_ips: list[str]) -> str:
 
 def render_backend(access_key: str, secret_key: str) -> str:
     """Render ``backend.hcl`` — the DO Spaces credentials for the S3 backend."""
-    return f'access_key = "{access_key}"\nsecret_key = "{secret_key}"\n'
+    return f"access_key = {json.dumps(access_key)}\nsecret_key = {json.dumps(secret_key)}\n"
 
 
 def _write_private(path: Path, content: str) -> Path:

--- a/tests/scripts/test_alerting.py
+++ b/tests/scripts/test_alerting.py
@@ -142,3 +142,24 @@ def test_empty_and_null_both_mean_no_open_issue(existing):
     runner = _label_present((0, existing))
     surface(False, "something broke", alert=ALERT, runner=runner)
     assert runner.ran("issue", "create")
+
+
+# --- CR1 finding 5: the comment's return code is checked too -----------------
+
+
+def test_reports_a_failed_recovery_comment(caplog):
+    """Same class as the create-path defect #414 fixed — do not skip the rc."""
+    runner = _label_present((0, "412"), (1, ""), (0, ""))  # comment FAILS, close ok
+    with caplog.at_level(logging.INFO):
+        surface(True, "", alert=ALERT, runner=runner)
+    messages = [r.getMessage().lower() for r in caplog.records]
+    assert any("comment failed" in m for m in messages)
+
+
+def test_a_failed_comment_still_closes_the_issue(caplog):
+    """The close is what matters; a missing comment must not strand the alert."""
+    runner = _label_present((0, "412"), (1, ""), (0, ""))
+    with caplog.at_level(logging.INFO):
+        surface(True, "", alert=ALERT, runner=runner)
+    assert runner.ran("issue", "close", "412")
+    assert any("closed recovered" in r.getMessage().lower() for r in caplog.records)

--- a/tests/scripts/test_check_egress_ip.py
+++ b/tests/scripts/test_check_egress_ip.py
@@ -353,3 +353,60 @@ def test_no_token_still_uses_the_env_var(monkeypatch, capsys):
         main()
     assert excinfo.value.code == 3
     assert "EGRESS_EXPECTED_IPS" in capsys.readouterr().out
+
+
+# --- CR1 findings 2 and 4: explicit flag wins; timeout is threaded -----------
+
+
+def test_an_explicit_expected_flag_beats_the_api(monkeypatch):
+    """CR1 finding 2: --expected silently lost to the API, so the flag lied.
+
+    An operator passing an allowlist explicitly is debugging; honour it.
+    """
+    monkeypatch.setenv("DO_API_TOKEN", "tok")
+    monkeypatch.setattr(sys, "argv", ["check_egress_ip", "--no-gh", "--expected", "1.2.3.4"])
+    monkeypatch.setattr("scripts.check_egress_ip.urlopen", _opener(b"69.67.149.183"))
+    monkeypatch.setattr(
+        "scripts.check_egress_ip.fetch_allowed_ips", lambda *a, **k: ["69.67.149.183"]
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 3  # drift against the explicit set, not the API
+
+
+def test_the_env_var_still_loses_to_the_api(monkeypatch, capsys):
+    """Only an explicitly-passed flag wins — the env var stays a fallback."""
+    monkeypatch.setenv("DO_API_TOKEN", "tok")
+    monkeypatch.setenv("EGRESS_EXPECTED_IPS", "1.2.3.4")
+    monkeypatch.setattr(sys, "argv", ["check_egress_ip", "--no-gh"])
+    monkeypatch.setattr("scripts.check_egress_ip.urlopen", _opener(b"69.67.149.183"))
+    monkeypatch.setattr(
+        "scripts.check_egress_ip.fetch_allowed_ips", lambda *a, **k: ["69.67.149.183"]
+    )
+    main()  # no SystemExit — the API says it is fine
+    assert "DO API" in capsys.readouterr().out
+
+
+def test_timeout_is_threaded_into_the_do_api_call(monkeypatch):
+    """CR1 finding 4: --timeout covered only the egress lookup."""
+    seen = {}
+
+    def recording(token, cluster, *, timeout=None, **kw):
+        seen["timeout"] = timeout
+        return ["69.67.149.183"]
+
+    monkeypatch.setenv("DO_API_TOKEN", "tok")
+    monkeypatch.setattr(sys, "argv", ["check_egress_ip", "--no-gh", "--timeout", "3"])
+    monkeypatch.setattr("scripts.check_egress_ip.urlopen", _opener(b"69.67.149.183"))
+    monkeypatch.setattr("scripts.check_egress_ip.fetch_allowed_ips", recording)
+    main()
+    assert seen["timeout"] == 3
+
+
+def test_an_explicit_but_empty_expected_is_unknown_not_drift(monkeypatch, capsys):
+    """`--expected ""` asks to compare against nothing; that is not a verdict."""
+    monkeypatch.setenv("DO_API_TOKEN", "tok")
+    monkeypatch.setattr(sys, "argv", ["check_egress_ip", "--no-gh", "--expected", ""])
+    monkeypatch.setattr("scripts.check_egress_ip.urlopen", _opener(b"69.67.149.183"))
+    main()  # no SystemExit
+    assert "could not determine the allowlist" in capsys.readouterr().out.lower()

--- a/tests/scripts/test_check_ready.py
+++ b/tests/scripts/test_check_ready.py
@@ -337,3 +337,36 @@ def test_main_gh_failure_does_not_mask_the_probe_result(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING), pytest.raises(SystemExit) as excinfo:
         main()
     assert excinfo.value.code == 3
+
+
+# --- CR1 finding 1: attempts must be a real count ---------------------------
+
+
+@pytest.mark.parametrize("attempts", ["0", "-1"])
+def test_main_rejects_a_non_positive_attempt_count(monkeypatch, attempts):
+    """Zero attempts probed nothing, then crashed on results[-1] (CR1 finding 1).
+
+    An env typo in /etc/power-map/.env must not turn the outage guard into a
+    unit that traps every two minutes without ever making a request.
+    """
+    monkeypatch.setattr(sys, "argv", ["check_ready", "--no-gh", "--attempts", attempts])
+    monkeypatch.setattr("scripts.check_ready.urlopen", _ok_opener())
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 2  # argparse usage error, not a traceback
+
+
+def test_main_rejects_a_non_positive_attempt_count_from_the_environment(monkeypatch):
+    monkeypatch.setenv("READY_PROBE_ATTEMPTS", "0")
+    monkeypatch.setattr(sys, "argv", ["check_ready", "--no-gh"])
+    monkeypatch.setattr("scripts.check_ready.urlopen", _ok_opener())
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 2
+
+
+def test_main_accepts_a_single_attempt(monkeypatch):
+    """1 is the floor, not an error — flap resistance is opt-out-able."""
+    monkeypatch.setattr(sys, "argv", ["check_ready", "--no-gh", "--attempts", "1"])
+    monkeypatch.setattr("scripts.check_ready.urlopen", _ok_opener())
+    main()  # no SystemExit

--- a/tests/scripts/test_do_api.py
+++ b/tests/scripts/test_do_api.py
@@ -78,3 +78,43 @@ def test_fetch_allowed_ips_raises_on_unknown_cluster():
 
 def test_requests_carry_the_bearer_token():
     assert _request("https://x", "tok123").get_header("Authorization") == "Bearer tok123"
+
+
+# --- CR1 finding 3: /v2/databases is paginated ------------------------------
+
+
+PAGE_1 = {
+    "databases": [{"id": "cid-a", "name": "other-1"}],
+    "links": {"pages": {"next": "https://api.digitalocean.com/v2/databases?page=2&per_page=200"}},
+}
+PAGE_2 = {"databases": [{"id": "cid-2", "name": "co-pm-db-1"}], "links": {"pages": {}}}
+
+
+def test_follows_pagination_to_find_a_later_cluster():
+    """DO pages at 20 by default; a cluster past page 1 used to raise LookupError."""
+    opener = _api(PAGE_1, PAGE_2, FIREWALL)
+    assert fetch_allowed_ips("token", "co-pm-db-1", opener=opener) == [
+        "69.67.149.183",
+        "67.213.124.9",
+    ]
+    assert "page=2" in opener.calls[1]
+
+
+def test_requests_a_large_page_size():
+    """Fewer round trips, and most accounts then need only one."""
+    opener = _api(CLUSTERS, FIREWALL)
+    fetch_allowed_ips("token", "co-pm-db-1", opener=opener)
+    assert "per_page=" in opener.calls[0]
+
+
+def test_stops_paging_once_the_cluster_is_found():
+    """No reason to walk the rest of the account."""
+    opener = _api(PAGE_2, FIREWALL)
+    fetch_allowed_ips("token", "co-pm-db-1", opener=opener)
+    assert len(opener.calls) == 2  # cluster page + firewall, no further paging
+
+
+def test_unknown_cluster_reports_after_exhausting_pages():
+    opener = _api(PAGE_1, PAGE_2, FIREWALL)
+    with pytest.raises(LookupError):
+        fetch_allowed_ips("token", "absent", opener=opener)

--- a/tests/scripts/test_write_terraform_credentials.py
+++ b/tests/scripts/test_write_terraform_credentials.py
@@ -142,3 +142,23 @@ def test_written_paths_are_reported_without_their_contents(tmp_path, capsys):
     captured = capsys.readouterr()
     assert "dop_v1_secrettoken" not in captured.out + captured.err
     assert "spaces+secret" not in captured.out + captured.err
+
+
+# --- CR1 finding 6: escape values into HCL string literals -------------------
+
+
+def test_render_tfvars_escapes_a_quote_in_the_token():
+    """A raw f-string would end the literal early and emit invalid HCL."""
+    out = render_tfvars('tok"en', ["1.2.3.4"])
+    assert 'do_token = "tok\\"en"' in out
+
+
+def test_render_backend_escapes_quotes_and_backslashes():
+    out = render_backend('ke"y', "sec\\ret")
+    assert 'access_key = "ke\\"y"' in out
+    assert 'secret_key = "sec\\\\ret"' in out
+
+
+def test_render_tfvars_escapes_allowlist_entries():
+    out = render_tfvars("t", ['1.2.3.4"]; evil = "'])
+    assert '1.2.3.4\\"]; evil = \\"' in out

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.29.0"
+version = "0.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Six findings from the code review of #347/#409/#410. Each was reproduced by a failing test before the fix; 11 tests were red at the start of this branch.

| # | Fix | Was |
|---|---|---|
| 1 | `--attempts` must be ≥ 1 | `--attempts 0` probed nothing, then `IndexError` on `results[-1]` |
| 2 | Explicit `--expected` beats the DO API | The flag silently lost, so it lied about what it compared |
| 3 | Page through `/v2/databases` | Paginated at 20; a cluster past page 1 read as absent |
| 4 | `--timeout` reaches the DO call | Only covered the egress lookup; the API kept its own 30s |
| 5 | Check the recovery comment's rc | Only `close` was checked — the defect #414 fixed on the create path |
| 6 | `json.dumps` into HCL | A quote in a secret ended the literal early |

## The two worth a closer look

**Finding 1 is the guard defeating itself.** `READY_PROBE_ATTEMPTS=0` in `/etc/power-map/.env` would have made the readiness guard raise every two minutes without ever issuing a request. It fails visibly (`systemctl --failed`), but as a traceback that reads like a code fault rather than the config typo it is.

**Finding 6 was live HCL injection**, not a theoretical escaping nit. The test asserts what the old code emitted:

```
allowed_external_ips = ["1.2.3.4"]; evil = ""]
```

DO tokens and Spaces keys are alphanumeric/base64 today, so nothing was ever broken — but the file being generated is one terraform reads as configuration.

Finding 3 deserves a note on why it mattered more than "latent": `resolve_allowlist` catches `Exception`, so the `LookupError` would have degraded the guard to the env-var fallback — or to nothing — without saying it had.

## New edge case, found while fixing 2

Making the flag win exposed `--expected ""`, which asks to compare against an empty set. That now reports "undetermined" rather than declaring drift against nothing.

## Verified

425 pass across `tests/scripts/` (11 new). Live on the VM:

| Command | Result |
|---|---|
| `check_ready --attempts 0` | `error: --attempts must be at least 1 (got 0)`, exit 2 |
| `check_egress_ip --expected 1.2.3.4` | `DRIFT — 69.67.149.183 is not in the allowlist (1.2.3.4; source: --expected)`, exit 3 |
| `check_egress_ip --timeout 5` | `in the allowlist (source: the DO API)`, exit 0 |

That last one ran the new paging code against the real DigitalOcean API.

Finding 7 (TDD commit shape) stet. Finding 8 (no automated check on the systemd units) noted on #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)