### PR TITLE
fix: CR round 2 — timing validation, HCL interpolation, bounded paging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.29.1"
+version = "0.29.2"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/_alerting.py
+++ b/scripts/_alerting.py
@@ -119,7 +119,7 @@ def surface(ok: bool, summary: str, *, alert: Alert, runner=None) -> None:
                 # The next run finds nothing open and tries again.
                 logger.warning("gh issue create failed (rc=%d) — no alert raised", rc)
         elif existing:
-            rc, _ = runner(
+            comment_rc, _ = runner(
                 [
                     "issue",
                     "comment",
@@ -129,15 +129,17 @@ def surface(ok: bool, summary: str, *, alert: Alert, runner=None) -> None:
                     "Auto-closing.",
                 ]
             )
-            if rc != 0:
+            if comment_rc != 0:
                 # Closing is what clears the alert, so press on regardless —
                 # but say the note is missing rather than implying it landed.
-                logger.warning("gh issue comment failed (rc=%d) — closing anyway", rc)
-            rc, _ = runner(["issue", "close", existing])
-            if rc == 0:
+                logger.warning("gh issue comment failed (rc=%d) — closing anyway", comment_rc)
+            close_rc, _ = runner(["issue", "close", existing])
+            if close_rc == 0:
                 logger.info("closed recovered issue #%s", existing)
             else:
-                logger.warning("gh issue close failed (rc=%d) — issue #%s left open", rc, existing)
+                logger.warning(
+                    "gh issue close failed (rc=%d) — issue #%s left open", close_rc, existing
+                )
     except Exception:
         # A broken gh must not turn a real failure into a clean exit.
         logger.warning("GitHub surfacing failed — guard result stands", exc_info=True)

--- a/scripts/_do_api.py
+++ b/scripts/_do_api.py
@@ -18,6 +18,9 @@ DEFAULT_CLUSTER = "co-pm-db-1"
 DEFAULT_TIMEOUT = 30.0
 # Large enough that a single page covers any realistic account.
 PAGE_SIZE = 200
+# A cursor that never terminates would otherwise spin until systemd killed the
+# unit, once every timer interval (CR2 finding 11).
+MAX_PAGES = 20
 
 
 def _request(url: str, token: str) -> urllib.request.Request:
@@ -43,10 +46,16 @@ def fetch_allowed_ips(
     # (CR1 finding 3). Ask for a large page, then follow the cursor anyway.
     url = f"{API_ROOT}/databases?per_page={PAGE_SIZE}"
     match = None
-    while url and match is None:
+    for _ in range(MAX_PAGES):
+        if url is None or match is not None:
+            break
         page = _get(url, token, opener=opener, timeout=timeout)
         match = next((c for c in page.get("databases", []) if c.get("name") == cluster_name), None)
         url = page.get("links", {}).get("pages", {}).get("next")
+        if url is not None and not url.startswith(API_ROOT):
+            # Every request carries the bearer token; a cursor taken from the
+            # response body must not steer it off DigitalOcean (CR2 finding 12).
+            raise ValueError(f"refusing to follow a pagination cursor off-host: {url}")
     if match is None:
         raise LookupError(f"no DigitalOcean database cluster named {cluster_name!r}")
     firewall = _get(

--- a/scripts/check_egress_ip.py
+++ b/scripts/check_egress_ip.py
@@ -121,11 +121,11 @@ def resolve_allowlist(
     compared (CR1 finding 2). The env var is not explicit and still loses.
     """
     if explicit:
-        # An explicit but empty set asks to compare against nothing — report it
-        # as undetermined rather than declaring drift against an empty list.
-        return (parse_expected(expected_raw) or None), (
-            "--expected" if expected_raw.strip() else UNKNOWN
-        )
+        parsed = parse_expected(expected_raw)
+        if not parsed:
+            # Asking to compare against nothing is not a verdict.
+            return None, UNKNOWN
+        return parsed, "--expected"
     if token:
         try:
             live = fetch_allowed_ips(token, cluster, timeout=timeout)
@@ -200,11 +200,15 @@ def main() -> None:
         )
         return
     if allowed is None:
-        logger.warning(
-            "could not determine the allowlist — no DO_API_TOKEN and no EGRESS_EXPECTED_IPS; "
-            "egress IP is %s",
-            current,
+        # Reached from several states (an empty --expected, no token and no env
+        # var, an API failure with no fallback), so name a cause only when it is
+        # actually the cause — misattributing it sends triage sideways.
+        hint = (
+            ""
+            if os.environ.get("DO_API_TOKEN")
+            else " — set DO_API_TOKEN or EGRESS_EXPECTED_IPS in /etc/power-map/.env"
         )
+        logger.warning("could not determine the allowlist; egress IP is %s%s", current, hint)
         return
 
     if current in allowed:

--- a/scripts/check_ready.py
+++ b/scripts/check_ready.py
@@ -207,11 +207,16 @@ def main() -> None:
         "--no-gh", action="store_true", help="skip GitHub surfacing (env READY_CHECK_NO_GH)"
     )
     args = parser.parse_args()
+    # These all come from /etc/power-map/.env, so a typo must produce a usage
+    # error rather than a traceback every two minutes: zero attempts probed
+    # nothing and crashed on results[-1] (CR1 finding 1), and a negative delay
+    # reached time.sleep (CR2 finding 9).
     if args.attempts < 1:
-        # Zero probed nothing and then crashed on results[-1] (CR1 finding 1).
-        # An env typo must not turn the outage guard into a trap that never
-        # makes a request.
         parser.error(f"--attempts must be at least 1 (got {args.attempts})")
+    if args.retry_delay < 0:
+        parser.error(f"--retry-delay must not be negative (got {args.retry_delay})")
+    if args.timeout <= 0:
+        parser.error(f"--timeout must be greater than 0 (got {args.timeout})")
     no_gh = args.no_gh or bool(os.environ.get("READY_CHECK_NO_GH"))
 
     if os.environ.get("READY_CHECK_FORCE_FAIL"):

--- a/scripts/write_terraform_credentials.py
+++ b/scripts/write_terraform_credentials.py
@@ -66,6 +66,17 @@ def parse_env(text: str) -> dict[str, str]:
     return parsed
 
 
+def _hcl(value: str) -> str:
+    """Render ``value`` as an HCL string literal, safe to paste into config.
+
+    ``json.dumps`` handles quotes and backslashes, but HCL string literals also
+    interpolate: verified against terraform, ``x = "a${b}"`` in a .tfvars fails
+    with "Variables not allowed", while ``a$${b}`` yields the literal text. So
+    the template openers need escaping too (CR2 finding 10).
+    """
+    return json.dumps(value).replace("${", "$${").replace("%{", "%%{")
+
+
 def render_tfvars(token: str, allowed_ips: list[str]) -> str:
     """Render ``terraform.tfvars``."""
     if not allowed_ips:
@@ -73,12 +84,9 @@ def render_tfvars(token: str, allowed_ips: list[str]) -> str:
         raise ValueError(
             "allowed_external_ips would be empty — the cluster would become unreachable"
         )
-    # json.dumps yields a correctly-escaped HCL string literal. A raw f-string
-    # let a quote in the value end the literal early and append arbitrary HCL
-    # (CR1 finding 6).
-    entries = ", ".join(json.dumps(ip) for ip in allowed_ips)
+    entries = ", ".join(_hcl(ip) for ip in allowed_ips)
     return (
-        f"do_token = {json.dumps(token)}\n\n"
+        f"do_token = {_hcl(token)}\n\n"
         "# Mirrors DO -> Databases -> Settings -> Trusted Sources, read from the API\n"
         f"# by scripts/write_terraform_credentials.py (#409).\n"
         f"allowed_external_ips = [{entries}]\n"
@@ -87,7 +95,7 @@ def render_tfvars(token: str, allowed_ips: list[str]) -> str:
 
 def render_backend(access_key: str, secret_key: str) -> str:
     """Render ``backend.hcl`` — the DO Spaces credentials for the S3 backend."""
-    return f"access_key = {json.dumps(access_key)}\nsecret_key = {json.dumps(secret_key)}\n"
+    return f"access_key = {_hcl(access_key)}\nsecret_key = {_hcl(secret_key)}\n"
 
 
 def _write_private(path: Path, content: str) -> Path:

--- a/tests/scripts/test_check_egress_ip.py
+++ b/tests/scripts/test_check_egress_ip.py
@@ -410,3 +410,23 @@ def test_an_explicit_but_empty_expected_is_unknown_not_drift(monkeypatch, capsys
     monkeypatch.setattr("scripts.check_egress_ip.urlopen", _opener(b"69.67.149.183"))
     main()  # no SystemExit
     assert "could not determine the allowlist" in capsys.readouterr().out.lower()
+
+
+def test_an_explicit_expected_of_only_separators_is_undetermined(monkeypatch, capsys):
+    """CR2 finding 13: the label and the emptiness check must not disagree."""
+    monkeypatch.setenv("DO_API_TOKEN", "tok")
+    monkeypatch.setattr(sys, "argv", ["check_egress_ip", "--no-gh", "--expected", ","])
+    monkeypatch.setattr("scripts.check_egress_ip.urlopen", _opener(b"69.67.149.183"))
+    main()  # no SystemExit
+    assert "could not determine the allowlist" in capsys.readouterr().out.lower()
+
+
+def test_undetermined_message_does_not_misattribute_the_cause(monkeypatch, capsys):
+    """With a token present, blaming a missing token sends triage the wrong way."""
+    monkeypatch.setenv("DO_API_TOKEN", "tok")
+    monkeypatch.setattr(sys, "argv", ["check_egress_ip", "--no-gh", "--expected", ","])
+    monkeypatch.setattr("scripts.check_egress_ip.urlopen", _opener(b"69.67.149.183"))
+    main()
+    out = capsys.readouterr().out
+    assert "could not determine the allowlist" in out.lower()
+    assert "no DO_API_TOKEN" not in out

--- a/tests/scripts/test_check_ready.py
+++ b/tests/scripts/test_check_ready.py
@@ -370,3 +370,42 @@ def test_main_accepts_a_single_attempt(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["check_ready", "--no-gh", "--attempts", "1"])
     monkeypatch.setattr("scripts.check_ready.urlopen", _ok_opener())
     main()  # no SystemExit
+
+
+# --- CR2 finding 9: validate every numeric input, not just attempts ---------
+
+
+@pytest.mark.parametrize(
+    "flag,value",
+    [("--retry-delay", "-1"), ("--timeout", "0"), ("--timeout", "-5")],
+)
+def test_main_rejects_nonsensical_timings(monkeypatch, flag, value):
+    """A negative delay reached time.sleep and raised ValueError (CR2 finding 9).
+
+    Same hazard as --attempts 0: these all come from /etc/power-map/.env, so a
+    typo must produce a usage error, not a traceback every two minutes.
+    """
+    monkeypatch.setattr(sys, "argv", ["check_ready", "--no-gh", flag, value])
+    monkeypatch.setattr("scripts.check_ready.urlopen", _ok_opener())
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "env,value", [("READY_PROBE_RETRY_DELAY", "-1"), ("READY_PROBE_TIMEOUT", "0")]
+)
+def test_main_rejects_nonsensical_timings_from_the_environment(monkeypatch, env, value):
+    monkeypatch.setenv(env, value)
+    monkeypatch.setattr(sys, "argv", ["check_ready", "--no-gh"])
+    monkeypatch.setattr("scripts.check_ready.urlopen", _ok_opener())
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 2
+
+
+def test_zero_retry_delay_is_allowed(monkeypatch):
+    """0 means 'retry immediately' — legitimate, and the tests rely on it."""
+    monkeypatch.setattr(sys, "argv", ["check_ready", "--no-gh", "--retry-delay", "0"])
+    monkeypatch.setattr("scripts.check_ready.urlopen", _ok_opener())
+    main()  # no SystemExit

--- a/tests/scripts/test_do_api.py
+++ b/tests/scripts/test_do_api.py
@@ -9,7 +9,7 @@ import json
 
 import pytest
 
-from scripts._do_api import _request, fetch_allowed_ips
+from scripts._do_api import API_ROOT, MAX_PAGES, _request, fetch_allowed_ips
 
 # --- fetch_allowed_ips -----------------------------------------------------
 
@@ -118,3 +118,49 @@ def test_unknown_cluster_reports_after_exhausting_pages():
     opener = _api(PAGE_1, PAGE_2, FIREWALL)
     with pytest.raises(LookupError):
         fetch_allowed_ips("token", "absent", opener=opener)
+
+
+# --- CR2 findings 11 and 12: bound the walk, keep it on DO ------------------
+
+
+def _endless_pages():
+    """A cursor that never terminates — the hang CR2 finding 11 guards against."""
+    calls = []
+
+    def opener(request, timeout=None):
+        calls.append(getattr(request, "full_url", request))
+        return _Response(
+            {
+                "databases": [{"id": "x", "name": "not-the-one"}],
+                "links": {"pages": {"next": f"{API_ROOT}/databases?page={len(calls) + 1}"}},
+            }
+        )
+
+    opener.calls = calls
+    return opener
+
+
+def test_paging_is_bounded():
+    """Unbounded, this spun until systemd killed the unit — every 5 minutes."""
+    opener = _endless_pages()
+    with pytest.raises(LookupError):
+        fetch_allowed_ips("token", "co-pm-db-1", opener=opener)
+    assert len(opener.calls) <= MAX_PAGES
+
+
+def test_refuses_to_follow_a_cursor_off_digitalocean():
+    """The bearer token rides on every request; it must not leave the host."""
+    off_host = {
+        "databases": [{"id": "x", "name": "other"}],
+        "links": {"pages": {"next": "https://evil.example/v2/databases?page=2"}},
+    }
+    opener = _api(off_host, FIREWALL)
+    with pytest.raises(ValueError) as excinfo:
+        fetch_allowed_ips("token", "co-pm-db-1", opener=opener)
+    assert "evil.example" in str(excinfo.value)
+    assert len(opener.calls) == 1  # never fetched
+
+
+def test_a_normal_next_cursor_is_still_followed():
+    opener = _api(PAGE_1, PAGE_2, FIREWALL)
+    assert fetch_allowed_ips("token", "co-pm-db-1", opener=opener)

--- a/tests/scripts/test_write_terraform_credentials.py
+++ b/tests/scripts/test_write_terraform_credentials.py
@@ -162,3 +162,33 @@ def test_render_backend_escapes_quotes_and_backslashes():
 def test_render_tfvars_escapes_allowlist_entries():
     out = render_tfvars("t", ['1.2.3.4"]; evil = "'])
     assert '1.2.3.4\\"]; evil = \\"' in out
+
+
+# --- CR2 finding 10: HCL interpolates, so json.dumps is not enough ----------
+
+
+def test_render_tfvars_escapes_hcl_interpolation():
+    """Verified against terraform: `x = "a${b}"` in a tfvars errors with
+    'Variables not allowed', while `a$${b}` yields the literal. json.dumps
+    escapes quotes but leaves ${ alone (CR2 finding 10).
+    """
+    out = render_tfvars("tok${var.evil}", ["1.2.3.4"])
+    assert "$${var.evil}" in out
+    assert '"tok${var.evil}"' not in out
+
+
+def test_render_tfvars_escapes_hcl_directives():
+    """%{ opens a template directive and needs %%{ just as ${ needs $${."""
+    out = render_tfvars("tok%{if true}", ["1.2.3.4"])
+    assert "%%{if true}" in out
+
+
+def test_render_backend_escapes_hcl_interpolation():
+    out = render_backend("key${x}", "secret%{y}")
+    assert "$${x}" in out
+    assert "%%{y}" in out
+
+
+def test_allowlist_entries_escape_interpolation_too():
+    out = render_tfvars("t", ["1.2.3.4${x}"])
+    assert "$${x}" in out

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.29.1"
+version = "0.29.2"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Six findings from the second review round. Nine tests were red at the start of this branch.

| # | Fix | Was |
|---|---|---|
| 9 | Validate `--retry-delay` and `--timeout` | Only `--attempts` was checked; `-1` reached `time.sleep` → `ValueError` |
| 10 | Escape `${` and `%{` for HCL | `json.dumps` handles quotes, not template interpolation |
| 11 | Cap the page walk at 20 | Unbounded — a non-terminating cursor spins until systemd kills the unit |
| 12 | Refuse a cursor that leaves DigitalOcean | The `next` URL came from the response body and carried the bearer token |
| 13 | Decide emptiness once | Two expressions that could disagree about the same thing |
| 14 | `comment_rc` / `close_rc` | One `rc` served both calls |

## Two that were more than tidying

**Finding 9 is the same defect round 1 fixed one-third of.** The argument for validating `--attempts` — these come from `/etc/power-map/.env`, so a typo must not make the outage guard trap every two minutes — applies unchanged to the other two inputs. `--retry-delay -1` still died with `ValueError: sleep length must be non-negative`.

**Finding 10 was verified against terraform, not assumed.** A scratch config proves `.tfvars` string literals interpolate:

```
x = "a${b}"    ->  Error: Variables not allowed
x = "a$${b}"   ->  x = "a${b}"
```

So round 1's `json.dumps` fix was incomplete on its own terms. Escaping now covers both `${` and `%{`.

## Found while verifying

The "could not determine the allowlist" warning blamed a missing `DO_API_TOKEN` even when a token was present and the explicit set was empty — it is reached from several states. It now names a cause only when that is the cause, while keeping the actionable hint for the genuinely-unconfigured case.

## Verified

441 pass across `tests/scripts/` (13 new). Live on the VM:

| Check | Result |
|---|---|
| `--retry-delay -1` | `error: --retry-delay must not be negative (got -1.0)`, exit 2 |
| `--timeout 0` | `error: --timeout must be greater than 0 (got 0.0)`, exit 2 |
| Real DO API walk | `in the allowlist (source: the DO API)`, exit 0 |
| `--expected ","` | `could not determine the allowlist`, exit 0 |

**The escaping change produces byte-identical output for the live credential files** — diffed against `infra/terraform/` before and after — and `terraform plan` remains clean. That was the risk worth checking: this code writes the files terraform reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)