### PR TITLE
fix: CR round 3 — distinguish the page cap from a missing cluster

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.29.2"
+version = "0.29.3"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/_do_api.py
+++ b/scripts/_do_api.py
@@ -11,9 +11,11 @@ databases and VPCs read, no account/projects/spaces access.
 
 import json
 import urllib.request
+from urllib.parse import urlparse
 from urllib.request import urlopen
 
-API_ROOT = "https://api.digitalocean.com/v2"
+API_HOST = "api.digitalocean.com"
+API_ROOT = f"https://{API_HOST}/v2"
 DEFAULT_CLUSTER = "co-pm-db-1"
 DEFAULT_TIMEOUT = 30.0
 # Large enough that a single page covers any realistic account.
@@ -52,11 +54,22 @@ def fetch_allowed_ips(
         page = _get(url, token, opener=opener, timeout=timeout)
         match = next((c for c in page.get("databases", []) if c.get("name") == cluster_name), None)
         url = page.get("links", {}).get("pages", {}).get("next")
-        if url is not None and not url.startswith(API_ROOT):
-            # Every request carries the bearer token; a cursor taken from the
+        if url is not None and urlparse(url).hostname != API_HOST:
+            # Every request carries the bearer token, so a cursor taken from the
             # response body must not steer it off DigitalOcean (CR2 finding 12).
+            # Compare the parsed hostname rather than a string prefix: prefix
+            # matching is only safe while API_ROOT keeps its /v2 segment, and
+            # nothing would flag an edit that dropped it (CR3 finding 16).
             raise ValueError(f"refusing to follow a pagination cursor off-host: {url}")
     if match is None:
+        if url is not None:
+            # Exiting with a cursor still in hand means the cap stopped the walk.
+            # Saying "no such cluster" here would assert absence we never
+            # established (CR3 finding 15).
+            raise LookupError(
+                f"stopped after {MAX_PAGES} pages without finding {cluster_name!r}; "
+                "more pages remain"
+            )
         raise LookupError(f"no DigitalOcean database cluster named {cluster_name!r}")
     firewall = _get(
         f"{API_ROOT}/databases/{match['id']}/firewall", token, opener=opener, timeout=timeout

--- a/scripts/check_egress_ip.py
+++ b/scripts/check_egress_ip.py
@@ -49,6 +49,7 @@ from urllib.request import urlopen
 
 from scripts._alerting import Alert, surface
 from scripts._do_api import DEFAULT_CLUSTER, fetch_allowed_ips
+from scripts._do_api import DEFAULT_TIMEOUT as DO_API_TIMEOUT
 from src.core.logging import configure_logging, get_logger
 
 logger = get_logger(__name__)
@@ -104,7 +105,7 @@ def resolve_allowlist(
     expected_raw: str,
     *,
     explicit: bool = False,
-    timeout: float = DEFAULT_TIMEOUT,
+    timeout: float = DO_API_TIMEOUT,
 ) -> tuple[set[str] | None, str]:
     """Return (allowlist, source label), preferring the live Trusted Sources.
 

--- a/tests/scripts/test_check_egress_ip.py
+++ b/tests/scripts/test_check_egress_ip.py
@@ -430,3 +430,14 @@ def test_undetermined_message_does_not_misattribute_the_cause(monkeypatch, capsy
     out = capsys.readouterr().out
     assert "could not determine the allowlist" in out.lower()
     assert "no DO_API_TOKEN" not in out
+
+
+def test_resolve_allowlist_defaults_to_the_do_api_timeout():
+    """CR3 finding 17: two same-named constants held different values."""
+    import inspect
+
+    from scripts import _do_api
+    from scripts.check_egress_ip import resolve_allowlist
+
+    default = inspect.signature(resolve_allowlist).parameters["timeout"].default
+    assert default == _do_api.DEFAULT_TIMEOUT

--- a/tests/scripts/test_do_api.py
+++ b/tests/scripts/test_do_api.py
@@ -164,3 +164,43 @@ def test_refuses_to_follow_a_cursor_off_digitalocean():
 def test_a_normal_next_cursor_is_still_followed():
     opener = _api(PAGE_1, PAGE_2, FIREWALL)
     assert fetch_allowed_ips("token", "co-pm-db-1", opener=opener)
+
+
+# --- CR3 findings 15 and 16 -------------------------------------------------
+
+
+def test_hitting_the_page_cap_is_not_reported_as_a_missing_cluster():
+    """CR3 finding 15: the cap said "no such cluster", asserting absence.
+
+    A mistyped --cluster and a 20-page account are different problems and must
+    not produce the same confident error.
+    """
+    opener = _endless_pages()
+    with pytest.raises(LookupError) as excinfo:
+        fetch_allowed_ips("token", "co-pm-db-1", opener=opener)
+    message = str(excinfo.value)
+    assert str(MAX_PAGES) in message
+    assert "no DigitalOcean database cluster named" not in message
+
+
+def test_a_genuinely_absent_cluster_still_says_so():
+    """The other half of 15 — the honest 'not found' must survive."""
+    opener = _api(PAGE_1, PAGE_2, FIREWALL)
+    with pytest.raises(LookupError) as excinfo:
+        fetch_allowed_ips("token", "absent", opener=opener)
+    assert "no DigitalOcean database cluster named" in str(excinfo.value)
+
+
+def test_refuses_a_lookalike_host():
+    """CR3 finding 16: prefix matching is safe only while API_ROOT keeps /v2.
+
+    Compare the parsed hostname so an edit to API_ROOT cannot weaken this.
+    """
+    lookalike = {
+        "databases": [{"id": "x", "name": "other"}],
+        "links": {"pages": {"next": "https://api.digitalocean.com.evil.example/v2/databases"}},
+    }
+    opener = _api(lookalike, FIREWALL)
+    with pytest.raises(ValueError) as excinfo:
+        fetch_allowed_ips("token", "co-pm-db-1", opener=opener)
+    assert "evil.example" in str(excinfo.value)

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.29.2"
+version = "0.29.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Three findings from the third review round. Converging: six findings in round 1, six in round 2, three here, one of them substantive.

| # | Fix | Was |
|---|---|---|
| 15 | Cap exhaustion says so | Fell through to "no such cluster", asserting an absence never established |
| 16 | Compare the parsed hostname | String prefix — safe only while `API_ROOT` keeps its `/v2` segment |
| 17 | One timeout default, owned by `_do_api` | Two same-named constants holding 10.0 and 30.0 |

## Finding 15 is the one that mattered

Round 2 asked for "cap **and log when the cap is hit**". The cap landed; the reporting didn't. So a mistyped `--cluster` and a genuinely 20-page account produced the same confident error — and because `resolve_allowlist` catches `Exception`, the journal would have stated the cluster was absent as fact while the guard quietly degraded to its fallback.

Exiting the loop with a cursor still in hand is exactly the signal that the cap stopped the walk, so the two causes are now distinguishable without adding a logger to the module.

That is the second round running where a fix stopped one step short of its own reasoning. Worth naming as a pattern, not just fixing again.

## Finding 16 is not a present fault

`https://api.digitalocean.com.evil.example/v2` does **not** match the current prefix, because `API_ROOT` pins the `/v2` path segment. The hazard is an edit that shortens the constant to the host — nothing would flag it, and the bearer token rides on every request. Comparing `urlparse(url).hostname` states the intent directly and cannot be weakened from a distance. A test now locks the lookalike case.

## Verified

445 pass across `tests/scripts/`. Live on the VM: the real DO API walk still resolves (`in the allowlist (source: the DO API)`), and a full credential rebuild from the API produces files byte-identical to those in `infra/terraform/` — which also confirms the API read and the on-disk allowlist agree now that the stale IP is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)