### PR TITLE
Batch B: axe-after-interaction (#367) + real-browser smoke of typeahead/merge flows (#368)

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,7 +1,11 @@
 # power-map — Accessibility (WCAG 2.1 AA)
 
 Accessibility conventions for the admin dashboard: markup rules the templates must
-follow, and the three test tiers that enforce them. Commands for the browser tier
+follow, and the four test tiers that enforce them: static template lint
+(`test_aria_labels.py`), the rendered-DOM lxml sweep (`test_a11y_render.py`), the
+full-page axe sweep (`test_a11y_browser.py`, #300) and axe-after-interaction
+(`test_a11y_browser_interactions.py`, #367 — modals, inline edit rows, merge mode
+and other states no server-rendered page reaches). Commands for the browser tiers
 live in `docs/TESTING.md` § Browser Testing.
 
 ---
@@ -209,8 +213,10 @@ Hint `id` convention: `{field_name}-hint`.
 
 ## Modal focus management
 
-All modals must trap focus and restore it on close. The delete modal in
-`partials/delete_modal.html` is the canonical example:
+All modals must trap focus and restore it on close. Open modal states are axe-swept
+by the interaction tier (#367), including stacked modals and the archived-entity
+delete confirm. The delete modal in `partials/delete_modal.html` is the canonical
+example:
 
 - Capture `document.activeElement` (the trigger) before moving focus
 - On open: focus first interactive element inside the modal

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -42,9 +42,9 @@ the lxml tier never drift.
 uv sync --group browser
 uv run --group browser playwright install chromium
 
-# Run the sweep (needs TEST_DATABASE_URL; env flags per § Environment)
+# Run the whole tier (needs TEST_DATABASE_URL; env flags per § Environment)
 uv run --group browser --env-file /etc/power-map/.env --env-file .env \
-    pytest tests/api/admin/test_a11y_browser.py -m browser
+    pytest tests/api/admin/ -m browser
 ```
 
 Notes:
@@ -58,8 +58,17 @@ Notes:
   alongside the integration suite against the same DB.
 - axe-core is SHA-pinned under `tests/vendor/` (see that README); the run
   verifies the hash at import.
-- v1 scope is full pages only. axe-after-interaction (open edit rows, modals)
-  and real-browser flow smoke are planned follow-ups (#367, #368).
+- **Three files, one marker** — the tier is marker-gated over the whole admin test
+  dir, so a new browser file is swept automatically (the weekly timer runs the same
+  invocation):
+  - `test_a11y_browser.py` (#300) — axe over every full-page admin GET route.
+  - `test_a11y_browser_interactions.py` (#367) — axe over post-interaction DOM the
+    server never renders: inline edit rows, merge mode, portal and stacked modals,
+    the archived-entity delete confirm.
+  - `test_browser_smoke.py` (#368) — not a11y: real-browser flow smoke (typeahead
+    select, merge confirm) behind the fast happy-dom Vitest tier. It **mutates**
+    data, so it seeds its own disposable rows and never touches the shared session
+    seed — keep that rule when adding flows.
 
 ### Weekly a11y sweep timer (production, #369)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-map",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Web service for mapping political and corporate power",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ asyncio_mode = "auto"
 asyncio_default_test_loop_scope = "session"
 markers = [
     "integration: marks tests that hit live external services; excluded by default (run with -m integration)",
-    "browser: marks Playwright real-browser tests (axe-core sweep, #300); excluded by default, never pre-commit (run with -m browser after `uv sync --group browser && playwright install chromium`)",
+    "browser: marks Playwright real-browser tests (axe sweeps + flow smoke; #300/#367/#368); excluded by default, never pre-commit (run with -m browser after `uv sync --group browser && playwright install chromium`)",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "power-map"
-version = "0.31.0"
+version = "0.32.0"
 description = "Web service for mapping political and corporate power: people, organizations, roles, and their temporal relationships."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/run-a11y-sweep.sh
+++ b/scripts/run-a11y-sweep.sh
@@ -3,8 +3,10 @@
 #
 # Runs both accessibility tiers against the dedicated test DB and surfaces the
 # result for operator review:
-#   - lxml rendered-DOM tier      (tests/api/admin/test_a11y_render.py  -m integration, #246)
-#   - Playwright/axe browser tier (tests/api/admin/test_a11y_browser.py -m browser,    #300)
+#   - lxml rendered-DOM tier      (tests/api/admin/test_a11y_render.py -m integration, #246)
+#   - Playwright browser tier     (tests/api/admin/ -m browser, #300) — the whole admin
+#     dir, marker-gated, so sibling browser files are picked up automatically:
+#     full-page axe sweep (#300), axe-after-interaction (#367), flow smoke (#368)
 #
 # Output: everything goes to stdout/stderr, which systemd captures to the journal
 # (`journalctl -u power-map-a11y`). The full failing detail (axe violations,
@@ -140,7 +142,7 @@ run_tier "lxml render tier" tests/api/admin/test_a11y_render.py -m integration -
 lxml_rc=$?
 
 log "running browser axe tier"
-run_tier "browser axe tier" tests/api/admin/test_a11y_browser.py -m browser --no-header -q -p no:cacheprovider
+run_tier "browser axe tier" tests/api/admin/ -m browser --no-header -q -p no:cacheprovider
 browser_rc=$?
 
 overall=0

--- a/tests/api/admin/test_a11y_browser_interactions.py
+++ b/tests/api/admin/test_a11y_browser_interactions.py
@@ -1,0 +1,194 @@
+"""Axe-core a11y checks on post-interaction admin DOM states (GH #367).
+
+The v1 browser sweep (``test_a11y_browser.py``, #300) runs axe over full pages
+only. This module drives the page into interactive states server-side rendering
+can't reach — inline edit rows, portal modals, merge mode — and runs axe on the
+resulting DOM. Targeted interaction scripts, not a blanket sweep: a few
+high-value states, each asserted reachable (a timed wait on a state marker)
+before axe runs, so a broken interaction fails loudly instead of passing
+vacuously against the pre-interaction page.
+
+States covered:
+
+- **Org contact inline edit row** — the ``edit-row`` swap pattern shared by
+  every ancillary table (contacts/links/identifiers/names/...).
+- **People list merge mode** — reveals the hidden ``.merge-col`` checkbox
+  column (labelled "Select ... for merge", #366) and the Keep A/B merge bar.
+- **People merge preview modal** — the #255 curated-merge modal opened into
+  ``#merge-modal-portal`` over the list page.
+- **Org merge search -> preview modals** — modal over a detail page: the
+  typeahead search modal, its populated listbox, then the preview modal that
+  replaces it in the portal (the full "Merge with..." Danger Zone flow).
+- **Archived person delete confirm modal** (#426 archived seeds) — the
+  ``hx-confirm`` interception is a real DOM modal (``admin-modal.js``), not a
+  browser-native dialog, so it is axe-evaluable. Closed via Escape.
+
+Nothing here mutates the shared session seed: every driven request is a GET
+(edit-row, merge previews) and destructive confirms are never submitted — the
+delete modal is cancelled, merge forms are left unsubmitted.
+
+Shares the #426 session fixtures (``live_server``, ``seeded_ids``, ``page``)
+from ``conftest.py`` and the SHA-pinned vendored axe-core asset. Same marker
+(``-m browser``) and isolation constraints as the full-page sweep; run it
+alone against the dedicated test DB (see docs/TESTING.md).
+"""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+# Same gate as the full-page sweep: only `-m browser` runs may need Playwright.
+pytest.importorskip(
+    "playwright.async_api",
+    reason="install the browser group: uv sync --group browser && playwright install chromium",
+)
+
+pytestmark = [pytest.mark.browser]
+
+# SHA-pinned vendored axe-core — same asset the full-page sweep injects (see
+# tests/vendor/README.md). The pin is repeated here deliberately: conftest and
+# the sweep are read-only foundation files for this module (#367 batch plan),
+# and the versioned filename means an axe upgrade must touch both pins anyway.
+_AXE_PATH = Path(__file__).parents[2] / "vendor" / "axe-core-4.10.2.min.js"
+_AXE_SHA256 = "b511cd9dec01c76f4b2ad1723b66b6db37d4c2eb4ed199076e1829d9ee7b75e3"
+_AXE_SOURCE = _AXE_PATH.read_text(encoding="utf-8")
+if hashlib.sha256(_AXE_SOURCE.encode("utf-8")).hexdigest() != _AXE_SHA256:
+    raise RuntimeError(
+        f"{_AXE_PATH.name} SHA-256 mismatch — vendored axe-core is corrupt or was swapped;"
+        " re-download the pinned version (see tests/vendor/README.md)"
+    )
+
+# In-page axe run (same shape as the sweep): violations only, trimmed to the
+# fields the failure message needs.
+_AXE_RUN_JS = """
+async () => {
+  const r = await axe.run(document, { resultTypes: ['violations'] });
+  return r.violations.map(v => ({
+    id: v.id,
+    impact: v.impact,
+    help: v.help,
+    helpUrl: v.helpUrl,
+    nodes: v.nodes.map(n => n.target.join(' ')),
+  }));
+}
+"""
+
+# Ceiling on every state-marker wait. Interaction swaps are local HTMX round
+# trips against a warm local server — if a state isn't reached in 5s the
+# interaction is broken, and a short ceiling keeps a red run fast.
+_WAIT_MS = 5_000
+
+
+def _format_violations(state: str, violations: list[dict]) -> str:
+    """Failure message in the sweep's format, keyed by interaction state."""
+    lines = [f"{state}: {len(violations)} axe-core violation(s):"]
+    for v in violations:
+        lines.append(f"  [{v['impact']}] {v['id']} — {v['help']} ({v['helpUrl']})")
+        for target in v["nodes"][:5]:
+            lines.append(f"      at: {target}")
+        if len(v["nodes"]) > 5:
+            lines.append(f"      … +{len(v['nodes']) - 5} more node(s)")
+    return "\n".join(lines)
+
+
+async def _axe_check(page, state: str) -> None:
+    """Run axe against the page's current DOM and assert zero violations.
+
+    Injects the vendored axe-core once per document — portal swaps and HTMX
+    row swaps keep the same document, so repeated checks after further
+    interaction reuse the already-injected copy.
+    """
+    if not await page.evaluate("() => !!window.axe"):
+        await page.add_script_tag(content=_AXE_SOURCE)
+    violations = await page.evaluate(_AXE_RUN_JS)
+    assert not violations, _format_violations(state, violations)
+
+
+async def _enter_people_merge_mode(page, live_server: str, seeded_ids: dict) -> None:
+    """Drive the People list into merge mode with both active people selected.
+
+    Ends with the merge bar's Keep buttons enabled (two selections) — the
+    state the merge-preview test continues from.
+    """
+    await page.goto(live_server + "/admin/people/", wait_until="domcontentloaded")
+    # Pre-interaction: the merge column exists but is hidden (display:none).
+    assert not await page.locator("th.merge-col").first.is_visible(), (
+        "merge column visible before entering merge mode — page state changed?"
+    )
+    await page.click("#people-merge-btn")
+    await page.wait_for_selector("th.merge-col", state="visible", timeout=_WAIT_MS)
+    for pid in (seeded_ids["person_id"], seeded_ids["person2_id"]):
+        await page.check(f'input[name="merge-select"][value="{pid}"]')
+    await page.wait_for_selector(".merge-bar__keep-a:not([disabled])", timeout=_WAIT_MS)
+
+
+async def test_org_contact_edit_row_axe_clean(live_server, seeded_ids, page):
+    """Open the seeded org contact's inline edit row and axe the edited state."""
+    contact_id = seeded_ids["org_sub"]["contact_id"]
+    await page.goto(
+        live_server + f"/admin/orgs/{seeded_ids['org_id']}/", wait_until="domcontentloaded"
+    )
+    row = f"#contact-row-{contact_id}"
+    # Pre-interaction: the read row has no form.
+    assert await page.locator(f"{row} form").count() == 0, "edit form present before interaction"
+    await page.click(f'{row} button[aria-label^="Edit contact"]')
+    await page.wait_for_selector(f'{row} form input[name="value"]', timeout=_WAIT_MS)
+    await _axe_check(page, "org detail — contact inline edit row open")
+
+
+async def test_people_list_merge_mode_axe_clean(live_server, seeded_ids, page):
+    """Enable merge mode on the People list — revealed .merge-col checkboxes
+    (labelled 'Select … for merge') and the two-selection merge bar — and axe."""
+    await _enter_people_merge_mode(page, live_server, seeded_ids)
+    await _axe_check(page, "people list — merge mode, two selected, merge bar shown")
+
+
+async def test_people_merge_preview_modal_axe_clean(live_server, seeded_ids, page):
+    """Open the merge preview modal (Keep button → portal) over the People list
+    and axe it. The merge form is never submitted."""
+    await _enter_people_merge_mode(page, live_server, seeded_ids)
+    await page.click(".merge-bar__keep-a")
+    await page.wait_for_selector("#merge-modal-portal #merge-form", timeout=_WAIT_MS)
+    await _axe_check(page, "people list — merge preview modal open")
+
+
+async def test_org_merge_search_and_preview_modals_axe_clean(live_server, seeded_ids, page):
+    """Drive the org Danger Zone 'Merge with…' flow: search modal over the
+    detail page, populated typeahead listbox, then the preview modal that
+    replaces it in the portal. Axe at each state; the merge is never posted."""
+    await page.goto(
+        live_server + f"/admin/orgs/{seeded_ids['org_id']}/", wait_until="domcontentloaded"
+    )
+    assert await page.locator("#merge-modal-portal .modal").count() == 0, (
+        "merge portal already populated before interaction"
+    )
+    await page.click('.danger-zone button[hx-get$="/merge-search/"]')
+    await page.wait_for_selector("#merge-modal-portal .modal", timeout=_WAIT_MS)
+    await _axe_check(page, "org detail — merge search modal open")
+
+    await page.fill("#merge-target-display", "A11y Org Two")
+    await page.wait_for_selector('#merge-target-results li[role="option"]', timeout=_WAIT_MS)
+    await _axe_check(page, "org detail — merge search modal, typeahead results shown")
+
+    await page.click('#merge-target-results li[role="option"]')
+    await page.wait_for_selector("#merge-modal-portal #merge-form", timeout=_WAIT_MS)
+    await _axe_check(page, "org detail — merge preview modal open")
+
+
+async def test_archived_person_delete_confirm_modal_axe_clean(live_server, seeded_ids, page):
+    """Open the Danger Zone delete confirm modal on an archived person detail
+    page (#426 archived seeds), axe it, then cancel via Escape — the DELETE is
+    never issued. hx-confirm renders a DOM modal here (admin-modal.js), so the
+    state is axe-evaluable, unlike a browser-native confirm()."""
+    await page.goto(
+        live_server + f"/admin/people/{seeded_ids['archived_person_id']}/",
+        wait_until="domcontentloaded",
+    )
+    assert await page.locator(".modal-backdrop").count() == 0, "modal open before interaction"
+    await page.click(".danger-zone button[hx-delete][hx-confirm]")
+    await page.wait_for_selector("#pm-confirm-title", timeout=_WAIT_MS)
+    await _axe_check(page, "archived person detail — delete confirm modal open")
+    # Cancel non-destructively and confirm the modal tears down.
+    await page.keyboard.press("Escape")
+    await page.wait_for_selector(".modal-backdrop", state="detached", timeout=_WAIT_MS)

--- a/tests/api/admin/test_browser_smoke.py
+++ b/tests/api/admin/test_browser_smoke.py
@@ -1,0 +1,218 @@
+"""Real-browser smoke tests of flows the happy-dom Vitest tier only simulates (GH #368).
+
+Two flows, thin end-state assertions — the slow real-DOM backstop behind the
+fast Vitest inner loop (`tests/js/`), never a re-implementation of it:
+
+1. **Typeahead select → HTMX swap → resulting DOM state.** The jurisdiction
+   combobox on the New Role form: real keystrokes drive the debounced HTMX
+   search, the factory (``typeahead-combobox.js``) opens the swapped-in
+   dropdown, and keyboard selection fills the hidden id — with real focus and
+   ``aria-*`` state that ``eval()``-mounted happy-dom can only approximate.
+2. **People list merge flow (select rows → preview modal → confirm).** Enter
+   merge mode, select two rows, open the merge-preview modal (#255), confirm —
+   asserting the modal's real focus placement, the post-merge list-region swap,
+   merge-mode exit on ``showFlash``, and that the winner's detail page reflects
+   the merge.
+
+A third case, ``test_typeahead_wires_on_hard_load``, is an ``xfail`` capturing
+a real divergence this tier exposed (deferred-script vs inline-mount ordering
+on hard page loads) — see its reason string.
+
+Runs on the shared browser-tier session fixtures in ``conftest.py`` (#300/#426):
+``live_server`` + ``page`` + ``seeded_ids``. The merge flow MUTATES data, so it
+seeds its own disposable people pair (module fixture below) and never touches
+the shared session seed other files rely on — session teardown truncates, so no
+cleanup is needed.
+
+Run (isolated, marker-gated — same constraints as ``test_a11y_browser.py``)::
+
+    uv run --group browser --env-file /etc/power-map/.env --env-file .env \\
+        pytest tests/api/admin/test_browser_smoke.py -m browser
+"""
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from src.core.db import generate_id
+
+# Skip cleanly when the browser extra isn't installed (default `uv run` syncs
+# only the dev group). The `browser` fixture in conftest.py re-guards.
+pytest.importorskip(
+    "playwright.async_api",
+    reason="install the browser group: uv sync --group browser && playwright install chromium",
+)
+
+pytestmark = [pytest.mark.browser]
+
+# Disposable merge-pair names. Distinct prefix so the list search (?q=…) shows
+# exactly these two rows — the shared seed's people never enter the flow.
+_WINNER_NAME = "Smoke Merge Winner"
+_LOSER_NAME = "Smoke Merge Loser"
+_MERGE_QUERY = "Smoke%20Merge"
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def merge_pair(browser_db, seeded_ids):
+    """Two disposable duplicate people for the merge flow (committed, so the
+    out-of-process server sees them).
+
+    The merge CONFIRMS and deletes the loser, so these rows are owned by this
+    module — the shared session seed (``seeded_ids``) stays intact for sibling
+    browser-test files. Depends on ``seeded_ids`` so the shared seed is already
+    committed before these rows join the list. No teardown: the session-scoped
+    ``browser_db`` fixture truncates all data tables at teardown.
+    """
+    conn = await asyncpg.connect(browser_db)
+    try:
+        pair = {"winner_id": generate_id(), "loser_id": generate_id()}
+        for pid, name in ((pair["winner_id"], _WINNER_NAME), (pair["loser_id"], _LOSER_NAME)):
+            await conn.execute("INSERT INTO people (id) VALUES ($1)", pid)
+            await conn.execute(
+                "INSERT INTO person_names (id, person_id, name, is_canonical)"
+                " VALUES ($1, $2, $3, TRUE)",
+                generate_id(),
+                pid,
+                name,
+            )
+    finally:
+        await conn.close()
+    return pair
+
+
+async def test_typeahead_select_fills_hidden_id(live_server, seeded_ids, page):
+    """Typeahead combobox: keystrokes → HTMX search swap → keyboard select.
+
+    Real-DOM behaviors the Vitest suite (`typeahead-combobox.test.js`)
+    simulates: the debounced `hx-get` round-trip, the `htmx:afterSwap`
+    dropdown-open, scoped `li` ids, `aria-activedescendant` keyboard
+    navigation, and focus remaining on the input after selection.
+
+    Reaches the New Role form via a **boosted navigation** from the roles list
+    — the admin shell's normal mode (`hx-boost`), where htmx executes the
+    form's inline factory-mount script after the deferred factory has loaded.
+    A direct hard load of the same page never wires the combobox at all — see
+    ``test_typeahead_wires_on_hard_load`` (xfail, product bug).
+    """
+    await page.goto(f"{live_server}/admin/roles/", wait_until="domcontentloaded")
+    await page.click('a[href="/admin/roles/new/"]')  # boosted nav (hx-boost shell)
+    await page.wait_for_selector("#role_type_id")
+
+    # The jurisdictional sub-fields are hidden until a role type is picked.
+    await page.select_option("#role_type_id", index=1)
+    box = page.locator("#structural-jurisdictional")
+    assert await box.is_visible()
+
+    # Real keystrokes drive HTMX's `input changed delay:200ms` trigger; the
+    # server-rendered results swap into the listbox and the factory opens it.
+    inp = page.locator("#jurisdiction-search")
+    await inp.click()
+    await inp.press_sequentially("A11y State", delay=25)
+    option = page.locator("#jurisdiction-search-results li[data-id]").first
+    await option.wait_for(state="visible", timeout=15_000)
+    assert await inp.get_attribute("aria-expanded") == "true"
+
+    # Scoped-id contract: afterSwap prefixes each option id with the listbox id.
+    li_id = await option.get_attribute("id")
+    assert li_id.startswith("jurisdiction-search-results-")
+
+    # Keyboard navigation: ArrowDown activates the option, Enter selects it.
+    await inp.press("ArrowDown")
+    assert await inp.get_attribute("aria-activedescendant") == li_id
+    await inp.press("Enter")
+
+    # Resulting DOM state: hidden id filled with the seeded jurisdiction, label
+    # in the visible input, dropdown closed and emptied, clear button revealed,
+    # and focus still on the combobox input (real focus — not simulatable).
+    assert await page.input_value("#jurisdiction-id-hidden") == seeded_ids["jurisdiction_id"]
+    assert await page.input_value("#jurisdiction-search") == "A11y State"
+    assert await inp.get_attribute("aria-expanded") == "false"
+    assert await page.locator("#jurisdiction-search-results li").count() == 0
+    assert await page.locator("#jurisdiction-clear").is_visible()
+    focused = await page.evaluate("document.activeElement && document.activeElement.id")
+    assert focused == "jurisdiction-search"
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="#368 real-browser divergence: typeahead-combobox.js is a deferred <head> "
+    "script, but roles/form.html mounts it from a plain inline <body> script, which "
+    "the browser runs during parse — before any deferred script executes. On a hard "
+    "load window.initTypeaheadCombobox is undefined, the typeof guard skips silently, "
+    "and the combobox is never wired (results swap in but the dropdown never opens). "
+    "Boosted navs work because htmx runs swapped-in scripts after the factory loaded. "
+    "happy-dom suites eval the factory before the mount script, so they cannot see "
+    "the ordering. Product fix is out of scope for this test-infra issue.",
+)
+async def test_typeahead_wires_on_hard_load(live_server, seeded_ids, page):
+    """Hard (non-boosted) load of the New Role form should also wire the
+    combobox — currently it does not (see xfail reason)."""
+    await page.goto(f"{live_server}/admin/roles/new/", wait_until="domcontentloaded")
+    await page.select_option("#role_type_id", index=1)
+    inp = page.locator("#jurisdiction-search")
+    await inp.click()
+    await inp.press_sequentially("A11y State", delay=25)
+    # If the factory were wired, its htmx:afterSwap handler would open the
+    # dropdown (and prefix the option ids). Short timeout: the swap itself
+    # lands well inside it; only the wiring is missing.
+    await page.locator("#jurisdiction-search-results li[data-id]").first.wait_for(
+        state="visible", timeout=5_000
+    )
+    assert await inp.get_attribute("aria-expanded") == "true"
+
+
+async def test_people_list_merge_flow(live_server, merge_pair, page):
+    """People list merge: merge mode → select 2 rows → preview modal → confirm.
+
+    Real-DOM behaviors the Vitest suites (`people-merge.test.js`,
+    `merge-modal-script.test.js`) simulate: the delegated merge-mode toggle,
+    checkbox selection driving the Keep buttons, the `hx-get` modal swap into
+    the portal with its focus placement, the confirm POST's list-region swap,
+    and merge-mode exit on the `showFlash` flash trigger.
+    """
+    winner, loser = merge_pair["winner_id"], merge_pair["loser_id"]
+    await page.goto(f"{live_server}/admin/people/?q={_MERGE_QUERY}", wait_until="domcontentloaded")
+    await page.wait_for_selector(f'tr[data-person-id="{winner}"]')
+    await page.wait_for_selector(f'tr[data-person-id="{loser}"]')
+
+    # Enter merge mode (document-delegated toggle) and select both rows.
+    await page.click("#people-merge-btn")
+    winner_cb = page.locator(f'tr[data-person-id="{winner}"] input[name="merge-select"]')
+    loser_cb = page.locator(f'tr[data-person-id="{loser}"] input[name="merge-select"]')
+    await winner_cb.check()
+    await loser_cb.check()
+
+    # Two selected: the bar offers both Keep buttons; A is the first-checked row.
+    bar = page.locator("#people-merge-bar")
+    assert await bar.is_visible()
+    keep_a = bar.locator(".merge-bar__keep-a")
+    assert await keep_a.inner_text() == f'Keep "{_WINNER_NAME}"'
+
+    # Keep winner → hx-get the merge-preview modal into the shared portal.
+    await keep_a.click()
+    await page.wait_for_selector("#merge-form")
+    assert await page.locator("#merge-name-winner").inner_text() == _WINNER_NAME
+    assert await page.locator("#merge-name-loser").inner_text() == _LOSER_NAME
+    # The portal script focuses the first button in the modal (real focus).
+    await page.wait_for_function(
+        "document.activeElement && document.activeElement.id === 'merge-swap-btn'",
+        timeout=5_000,
+    )
+
+    # Confirm the merge.
+    await page.click("#merge-execute-btn")
+
+    # Resulting DOM state: the list region re-renders without the loser, the
+    # modal portal empties, and showFlash exits merge mode.
+    await page.wait_for_selector(f'tr[data-person-id="{loser}"]', state="detached", timeout=15_000)
+    await page.wait_for_selector(f'tr[data-person-id="{winner}"]')
+    assert await page.locator("#merge-form").count() == 0
+    await page.wait_for_function(
+        "document.getElementById('people-merge-btn').textContent === 'Merge'", timeout=5_000
+    )
+    assert not await page.locator(f'tr[data-person-id="{winner}"] td.merge-col').is_visible()
+
+    # The merged entity's page reflects the merge: the loser's canonical name
+    # survives as an alias on the winner (default keep_name_ids all-checked).
+    await page.goto(f"{live_server}/admin/people/{winner}/", wait_until="domcontentloaded")
+    assert _LOSER_NAME in await page.locator("#names-table").inner_text()

--- a/tests/api/admin/test_browser_smoke.py
+++ b/tests/api/admin/test_browser_smoke.py
@@ -134,7 +134,10 @@ async def test_typeahead_select_fills_hidden_id(live_server, seeded_ids, page):
 
 
 @pytest.mark.xfail(
-    strict=False,
+    # strict: when #435 is fixed this XPASSes and fails the run, forcing the flip
+    # to a plain test. A Chromium crash (#436) yields XFAIL, not XPASS, so strict
+    # adds no flake exposure.
+    strict=True,
     reason="#368 real-browser divergence: typeahead-combobox.js is a deferred <head> "
     "script, but roles/form.html mounts it from a plain inline <body> script, which "
     "the browser runs during parse — before any deferred script executes. On a hard "

--- a/tests/sh/run_a11y_sweep.bats
+++ b/tests/sh/run_a11y_sweep.bats
@@ -56,8 +56,16 @@ setup() {
     export STUB_UV_LXML_RC=1
     run_sweep
     [ "$status" -eq 1 ]
-    [ "$(call_count "$STUB_UV_CALL_LOG" test_a11y_render.py)" -eq 1 ]
-    [ "$(call_count "$STUB_UV_CALL_LOG" test_a11y_browser.py)" -eq 1 ]
+    [ "$(call_count "$STUB_UV_CALL_LOG" '-m integration')" -eq 1 ]
+    [ "$(call_count "$STUB_UV_CALL_LOG" '-m browser')" -eq 1 ]
+}
+
+@test "browser tier sweeps the whole admin dir, so sibling files are picked up" {
+    # Marker-gated directory sweep, not a hardcoded file: #367/#368 added
+    # sibling browser-test files that a single-file invocation never ran.
+    run_sweep
+    [ "$status" -eq 0 ]
+    [ "$(call_count "$STUB_UV_CALL_LOG" 'tests/api/admin/ -m browser')" -eq 1 ]
 }
 
 # --- gh_surface open/update/close dedup -------------------------------------

--- a/tests/sh/stubs/uv
+++ b/tests/sh/stubs/uv
@@ -4,10 +4,13 @@
 # run-a11y-sweep.sh invokes uv in exactly three shapes; each maps to an env knob:
 #   `uv run --group browser … python -`  (Chromium guard, heredoc on stdin)
 #     → exit ${STUB_UV_GUARD_RC:-0}
-#   `uv run … pytest tests/api/admin/test_a11y_render.py …`   (lxml tier)
+#   `uv run … pytest … -m integration …`  (lxml tier)
 #     → print ${STUB_UV_LXML_OUTPUT:-} and exit ${STUB_UV_LXML_RC:-0}
-#   `uv run … pytest tests/api/admin/test_a11y_browser.py …`  (browser tier)
+#   `uv run … pytest … -m browser …`      (browser tier)
 #     → print ${STUB_UV_BROWSER_OUTPUT:-} and exit ${STUB_UV_BROWSER_RC:-0}
+#
+# Tiers are matched on their pytest marker, not their path: the browser tier
+# sweeps a directory (#367/#368 siblings), so a path match would be brittle.
 #
 # Every invocation is appended to $STUB_UV_CALL_LOG for "was uv called" asserts.
 set -u
@@ -28,11 +31,11 @@ case "$args" in
         [ "$rc" -eq 0 ] && echo "chromium OK"
         exit "$rc"
         ;;
-    *test_a11y_render.py*)
+    *-m\ integration*)
         [ -n "${STUB_UV_LXML_OUTPUT:-}" ] && printf '%s\n' "$STUB_UV_LXML_OUTPUT"
         exit "${STUB_UV_LXML_RC:-0}"
         ;;
-    *test_a11y_browser.py*)
+    *-m\ browser*)
         [ -n "${STUB_UV_BROWSER_OUTPUT:-}" ] && printf '%s\n' "$STUB_UV_BROWSER_OUTPUT"
         exit "${STUB_UV_BROWSER_RC:-0}"
         ;;

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,7 @@ wheels = [
 
 [[package]]
 name = "power-map"
-version = "0.31.0"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
Batch B of the test-infra backlog clearance (#433, plan: `docs/plans/2026-08-13-test-infra-backlog.md`). Two parallel workers, one new test file each; all foundation files (`conftest.py`, `admin_routes.py`, `test_a11y_browser.py`) untouched, as planned.

## #367 — axe-after-interaction (`test_a11y_browser_interactions.py`)
5 interaction states the full-page sweep can't see, each axe-swept post-interaction (7 axe evaluations total, all clean):
- org contact inline edit-row (the shared ancillary-table swap pattern)
- people-list merge mode (the hidden `.merge-col` "Select" checkboxes from #366, now asserted under axe)
- people merge preview modal (portal)
- org "Merge with…" stacked-modal flow (search modal → typeahead listbox → preview modal, 3 axe runs)
- archived-person delete-confirm modal (#426 seeds) — `hx-confirm` is intercepted into a DOM `role="dialog"` by `admin-modal.js`, so it IS axe-evaluable; cancelled via Escape, nothing destructive ever confirmed

## #368 — real-browser smoke (`test_browser_smoke.py`)
- typeahead: real keystrokes → debounced HTMX search → combobox ARIA state → Enter fills the hidden id, focus stays put
- people merge flow end-to-end (toggle → select → preview → **execute**) against its own disposable seeded pair — the shared session seed is never mutated
- plus `test_typeahead_wires_on_hard_load`, `xfail(strict=False)` pinning **#435** (typeahead never wires on hard load — inline body mount races the deferred factory; found by this tier, exactly what #368 existed to catch). Flip to a plain test as the acceptance check when fixing #435.

## Gate verification (run on this branch)
- Full non-browser suite: **4687 passed, 34 skipped** (9m45s)
- Browser tier alone (all 3 files, one session): **40 passed, 162 designed skips, 1 xfailed** — first run hit one `net::ERR_ABORTED` renderer crash on a pre-existing sweep route (the #436 kernel/Chromium flake, second instance recorded there); immediate retry 100% green
- Vitest 323 passed · fast admin suite 617 passed · all pre-commit hooks green · version bumped to 0.32.0

Closes #367. Closes #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
